### PR TITLE
fix(android): 修正gradle配置文件的锚点匹配规则

### DIFF
--- a/plugin/src/android/appBuildGradle.ts
+++ b/plugin/src/android/appBuildGradle.ts
@@ -212,8 +212,8 @@ export const withAndroidAppBuildGradle: ConfigPlugin = (config) =>
         src,
         newSrc: getManifestPlaceholders(),
         tag: 'jpush-manifest-placeholders',
-        anchor: /ndk\s*\{/,  // 在 NDK 配置后插入
-        offset: 1,
+        anchor: /defaultConfig\s*\{/,  // 在 defaultConfig 块内插入
+        offset: 1,  // 在 defaultConfig { 的下一行插入
         comment: '//',
       });
     });

--- a/plugin/src/android/appBuildGradle.ts
+++ b/plugin/src/android/appBuildGradle.ts
@@ -212,7 +212,7 @@ export const withAndroidAppBuildGradle: ConfigPlugin = (config) =>
         src,
         newSrc: getManifestPlaceholders(),
         tag: 'jpush-manifest-placeholders',
-        anchor: /abiFilters.*\n.*\}/,  // 在 NDK 配置后插入
+        anchor: /ndk\s*\{/,  // 在 NDK 配置后插入
         offset: 1,
         comment: '//',
       });

--- a/plugin/src/android/projectBuildGradle.ts
+++ b/plugin/src/android/projectBuildGradle.ts
@@ -32,7 +32,9 @@ const getVendorClasspaths = (): string => {
  * 生成华为 Maven 仓库配置
  */
 const getHuaweiMavenRepo = (): string => {
-  return `maven { url 'https://developer.huawei.com/repo/' }`;
+  return `repositories {
+        maven { url 'https://developer.huawei.com/repo/' }
+    }`;
 };
 
 /**
@@ -65,14 +67,32 @@ export const withAndroidProjectBuildGradle: ConfigPlugin = (config) =>
       validator.register('developer.huawei.com', (src) => {
         console.log('\n[MX_JPush_Expo] 配置 project build.gradle 华为 Maven 仓库 ...');
         
-        return mergeContents({
-          src,
-          newSrc: getHuaweiMavenRepo(),
-          tag: 'jpush-huawei-maven',
-          anchor: /repositories\s*\{/,
-          offset: 1,
-          comment: '//',
-        });
+        // 检查是否已存在 repositories 块
+        const hasRepositoriesBlock = /repositories\s*\{/.test(src);
+        
+        if (hasRepositoriesBlock) {
+          // 如果已存在 repositories 块，在其中添加华为 Maven 仓库
+          return mergeContents({
+            src,
+            newSrc: `maven { url 'https://developer.huawei.com/repo/' }`,
+            tag: 'jpush-huawei-maven',
+            anchor: /repositories\s*\{/,
+            offset: 1,
+            comment: '//',
+          });
+        } else {
+          // 如果不存在 repositories 块，添加完整的 repositories 块
+          return mergeContents({
+            src,
+            newSrc: `repositories {
+        maven { url 'https://developer.huawei.com/repo/' }
+    }`,
+            tag: 'jpush-huawei-maven',
+            anchor: /allprojects\s*\{/,
+            offset: 1,
+            comment: '//',
+          });
+        }
       });
     }
 

--- a/plugin/src/android/projectBuildGradle.ts
+++ b/plugin/src/android/projectBuildGradle.ts
@@ -69,7 +69,7 @@ export const withAndroidProjectBuildGradle: ConfigPlugin = (config) =>
           src,
           newSrc: getHuaweiMavenRepo(),
           tag: 'jpush-huawei-maven',
-          anchor: /allprojects\s*\{[\s\S]*?repositories\s*\{/,
+          anchor: /repositories\s*\{/,
           offset: 1,
           comment: '//',
         });

--- a/plugin/src/android/settingsGradle.ts
+++ b/plugin/src/android/settingsGradle.ts
@@ -35,7 +35,7 @@ export const withAndroidSettingsGradle: ConfigPlugin = (config) =>
         src,
         newSrc: getJPushModules(),
         tag: 'jpush-modules',
-        anchor: /includeBuild\(expoAutolinking\.reactNativeGradlePlugin\)/,
+        anchor: /include\s+['"]?:app['"]?/,
         offset: -1,  // 在锚点上方插入
         comment: '//',
       });


### PR DESCRIPTION
更新appBuildGradle.ts、settingsGradle.ts和projectBuildGradle.ts中的锚点正则表达式，使其更精确匹配目标位置，变得宽松匹配

#3 
#4 