### PR TITLE
refactor(android): update NDK ABI filters configuration

### DIFF
--- a/plugin/src/android/appBuildGradle.ts
+++ b/plugin/src/android/appBuildGradle.ts
@@ -14,8 +14,7 @@ import { Validator } from '../utils/codeValidator';
 const getNdkConfig = (): string => {
   return `ndk {
                 //选择要添加的对应 cpu 类型的 .so 库。
-                abiFilters 'armeabi', 'armeabi-v7a', 'arm64-v8a'
-                // 还可以添加 'x86', 'x86_64', 'mips', 'mips64'
+                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
             }`;
 };
 


### PR DESCRIPTION
- Reorder ABI filters to prioritize arm64-v8a and armeabi-v7a architectures
- Add x86 and x86_64 support for broader device compatibility
- Remove outdated mips and mips64 architecture references
- Simplify NDK configuration by removing redundant comment about additional CPU types