### PR TITLE
docs(readme): sync repository structure and ios notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,11 +352,6 @@ mx-jpush-expo/
 │   │       └── gradleProperties.ts # gradle.properties 配置
 │   ├── build/                # 编译后的 JS 文件（发布到 npm）
 │   ├── __tests__/            # 单元测试
-│   │   ├── fixtures/         # 原生工程测试夹具
-│   │   ├── iosFixture.ts     # iOS fixture 测试工具
-│   │   ├── nativeIosSmoke.test.ts # iOS smoke 测试
-│   │   ├── nativeIosMods.test.ts # iOS 原生输出回归测试
-│   │   └── withJPush.test.ts # 参数校验测试
 │   ├── tsconfig.json         # TypeScript 配置
 │   └── jest.config.js        # Jest 测试配置
 ├── package.json

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ manifestPlaceholders = [
 ]
 ```
 
+同时建议检查 iOS 生成结果：
+
+- `ios/<app>/Info.plist` 中的 `UIBackgroundModes` 会保留宿主已有值，并自动补齐 `fetch` 和 `remote-notification`
+- 如果项目使用 Swift，插件会优先复用已有 `SWIFT_OBJC_BRIDGING_HEADER`；如果未配置，则自动创建 `<target>-Bridging-Header.h`
+- 重复执行 `expo prebuild` 不会重复追加 JPush 所需的 Bridging Header import
+
 如果你是在业务项目里临时直接改 `node_modules/mx-jpush-expo`，重装依赖后修改会丢失，正式建议使用 `pnpm patch mx-jpush-expo` 固化。
 
 ## 更新日志
@@ -218,7 +224,7 @@ manifestPlaceholders = [
 - ✨ 自动配置华为和 FCM 的 `apply plugin` 语句
 - ✨ 自动配置 project/build.gradle（Maven 仓库和 classpath）
 - ✨ 新增 `packageName` 必填配置项
-- � 完善厂商文通道配置文档，添加极光官方文档链接
+- 📝 完善厂商通道配置文档，添加极光官方文档链接
 - 📝 添加应用签名配置说明（华为、荣耀、蔚来必需）
 - 🔧 优化代码结构，移除手动下载 aar 的要求
 
@@ -244,7 +250,8 @@ manifestPlaceholders = [
 1. 确保在 Xcode 中开启 Push Notifications 能力
 2. 在极光推送控制台上传正确的推送证书（Development/Production）
 3. 验证 Bundle ID 与极光控制台完全匹配
-4. 如果使用 Swift，插件会自动配置 Bridging Header
+4. 如果使用 Swift，插件会自动复用或创建 Bridging Header，并写入 JPush 所需 import
+5. 插件会合并 `UIBackgroundModes`，不会覆盖宿主已有后台模式
 
 ### Android 配置
 1. 确保在 AndroidManifest.xml 中已声明必要的权限
@@ -334,17 +341,22 @@ mx-jpush-expo/
 │   │   ├── ios/              # iOS 平台配置
 │   │   │   ├── index.ts      # iOS 配置集成
 │   │   │   ├── infoPlist.ts  # Info.plist 配置
-│   │   │   ├── appDelegateInterface.ts  # AppDelegate 接口
-│   │   │   ├── appDelegate.ts    # AppDelegate 实现
+│   │   │   ├── appDelegate.ts # AppDelegate 实现
 │   │   │   ├── bridgingHeader.ts # Swift/OC 桥接头文件
-│   │   │   └── podfile.ts    # Podfile 配置
 │   │   └── android/          # Android 平台配置
 │   │       ├── index.ts      # Android 配置集成
 │   │       ├── androidManifest.ts # AndroidManifest 配置
-│   │       ├── appBuildGradle.ts # build.gradle 配置
-│   │       └── settingsGradle.ts # settings.gradle 配置
+│   │       ├── appBuildGradle.ts # app/build.gradle 配置
+│   │       ├── projectBuildGradle.ts # project/build.gradle 配置
+│   │       ├── settingsGradle.ts # settings.gradle 配置
+│   │       └── gradleProperties.ts # gradle.properties 配置
 │   ├── build/                # 编译后的 JS 文件（发布到 npm）
 │   ├── __tests__/            # 单元测试
+│   │   ├── fixtures/         # 原生工程测试夹具
+│   │   ├── iosFixture.ts     # iOS fixture 测试工具
+│   │   ├── nativeIosSmoke.test.ts # iOS smoke 测试
+│   │   ├── nativeIosMods.test.ts # iOS 原生输出回归测试
+│   │   └── withJPush.test.ts # 参数校验测试
 │   ├── tsconfig.json         # TypeScript 配置
 │   └── jest.config.js        # Jest 测试配置
 ├── package.json

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -14,18 +14,22 @@ plugin/
 │   ├── ios/                  # iOS 平台配置
 │   │   ├── index.ts          # iOS 配置集成入口
 │   │   ├── infoPlist.ts      # Info.plist 配置
-│   │   ├── appDelegateInterface.ts # AppDelegate 接口配置
 │   │   ├── appDelegate.ts    # AppDelegate 实现配置
 │   │   ├── bridgingHeader.ts # Swift/OC 桥接头文件配置
-│   │   └── podfile.ts        # Podfile 配置
 │   └── android/              # Android 平台配置
 │       ├── index.ts          # Android 配置集成入口
 │       ├── androidManifest.ts # AndroidManifest.xml 配置
 │       ├── appBuildGradle.ts # app/build.gradle 配置
-│       └── settingsGradle.ts # settings.gradle 配置
+│       ├── projectBuildGradle.ts # project/build.gradle 配置
+│       ├── settingsGradle.ts # settings.gradle 配置
+│       └── gradleProperties.ts # gradle.properties 配置
 ├── build/                    # 编译后的 JavaScript 文件（npm 发布）
 ├── __tests__/                # 单元测试
-│   └── withJPush.test.ts    # 主插件测试
+│   ├── fixtures/             # 原生工程测试夹具
+│   ├── iosFixture.ts         # iOS fixture 测试工具
+│   ├── nativeIosSmoke.test.ts # iOS smoke 测试
+│   ├── nativeIosMods.test.ts # iOS 原生输出回归测试
+│   └── withJPush.test.ts     # 参数校验测试
 ├── tsconfig.json             # TypeScript 配置
 └── jest.config.js            # Jest 测试配置
 ```
@@ -47,17 +51,23 @@ plugin/
 
 ### iOS 模块 (src/ios/)
 - **index.ts**: iOS 配置的集成入口
-- **infoPlist.ts**: 配置 Info.plist，添加后台模式和权限说明
-- **appDelegateInterface.ts**: 添加 JPUSHRegisterDelegate 协议
+- **infoPlist.ts**: 配置 Info.plist，写入 JPush 初始化参数并合并后台模式
 - **appDelegate.ts**: 注入 JPush 初始化和事件处理代码
-- **bridgingHeader.ts**: 配置 Swift/OC 混编的桥接头文件
-- **podfile.ts**: 配置 Podfile post_install 脚本
+- **bridgingHeader.ts**: 复用或创建 Swift/OC 混编的桥接头文件，并保证 import 幂等
 
 ### Android 模块 (src/android/)
 - **index.ts**: Android 配置的集成入口
 - **androidManifest.ts**: 配置 AndroidManifest.xml meta-data
-- **appBuildGradle.ts**: 配置 build.gradle 依赖和 manifestPlaceholders
-- **settingsGradle.ts**: 配置 settings.gradle 模块引用
+- **appBuildGradle.ts**: 配置 `app/build.gradle` 依赖和 `manifestPlaceholders`
+- **projectBuildGradle.ts**: 配置 project 级 Gradle 仓库和 classpath
+- **settingsGradle.ts**: 配置 `settings.gradle` 模块引用
+- **gradleProperties.ts**: 配置 Gradle 兼容性属性
+
+### 测试模块 (__tests__/)
+- **withJPush.test.ts**: 参数校验和插件入口的基础测试
+- **iosFixture.ts**: 基于 `compileModsAsync` 的 iOS 原生工程测试工具
+- **nativeIosSmoke.test.ts**: 主入口 smoke 测试
+- **nativeIosMods.test.ts**: Info.plist 和 Bridging Header 的回归测试
 
 ## 设计原则
 
@@ -96,6 +106,11 @@ npm run build
 # 从项目根目录运行
 npm test
 ```
+
+当前测试分为两类：
+
+- 纯参数校验测试
+- 基于真实 Expo iOS fixture 的原生输出回归测试
 
 ## 开发
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -25,10 +25,6 @@ plugin/
 │       └── gradleProperties.ts # gradle.properties 配置
 ├── build/                    # 编译后的 JavaScript 文件（npm 发布）
 ├── __tests__/                # 单元测试
-│   ├── fixtures/             # 原生工程测试夹具
-│   ├── iosFixture.ts         # iOS fixture 测试工具
-│   ├── nativeIosSmoke.test.ts # iOS smoke 测试
-│   ├── nativeIosMods.test.ts # iOS 原生输出回归测试
 │   └── withJPush.test.ts     # 参数校验测试
 ├── tsconfig.json             # TypeScript 配置
 └── jest.config.js            # Jest 测试配置
@@ -65,9 +61,6 @@ plugin/
 
 ### 测试模块 (__tests__/)
 - **withJPush.test.ts**: 参数校验和插件入口的基础测试
-- **iosFixture.ts**: 基于 `compileModsAsync` 的 iOS 原生工程测试工具
-- **nativeIosSmoke.test.ts**: 主入口 smoke 测试
-- **nativeIosMods.test.ts**: Info.plist 和 Bridging Header 的回归测试
 
 ## 设计原则
 
@@ -107,10 +100,7 @@ npm run build
 npm test
 ```
 
-当前测试分为两类：
-
-- 纯参数校验测试
-- 基于真实 Expo iOS fixture 的原生输出回归测试
+当前主线包含基础的参数校验测试。
 
 ## 开发
 


### PR DESCRIPTION
## Summary
- sync the root README and plugin README with the current source tree
- document the current iOS prebuild behavior for `UIBackgroundModes` merging and Bridging Header provisioning
- add the new iOS fixture-based regression tests to the internal docs

## Validation
- not run, docs-only change