### PR TITLE
test(plugin): expand Android and AppDelegate regression coverage

### DIFF
--- a/plugin/__tests__/androidFixture.ts
+++ b/plugin/__tests__/androidFixture.ts
@@ -1,0 +1,74 @@
+import { compileModsAsync } from 'expo/config-plugins';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import withJPush from '../src';
+import { JPushPluginProps } from '../src/types';
+import { createExpoConfig, createPluginProps } from './testProps';
+
+export const FIXTURE_ROOT = path.join(__dirname, 'fixtures', 'android-project');
+export const APP_BUILD_GRADLE_PATH = ['android', 'app', 'build.gradle'];
+export const ANDROID_MANIFEST_PATH = [
+  'android',
+  'app',
+  'src',
+  'main',
+  'AndroidManifest.xml',
+];
+export const PROJECT_BUILD_GRADLE_PATH = ['android', 'build.gradle'];
+export const SETTINGS_GRADLE_PATH = ['android', 'settings.gradle'];
+export const GRADLE_PROPERTIES_PATH = ['android', 'gradle.properties'];
+
+const tempProjectRoots: string[] = [];
+
+export function registerAndroidFixtureLifecycleHooks(): void {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+
+    while (tempProjectRoots.length > 0) {
+      const projectRoot = tempProjectRoots.pop();
+      if (projectRoot) {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+      }
+    }
+  });
+}
+
+export function getFixturePath(projectRoot: string, segments: string[]): string {
+  return path.join(projectRoot, ...segments);
+}
+
+export function createProjectRoot(): string {
+  const projectRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'mx-jpush-android-')
+  );
+  fs.cpSync(FIXTURE_ROOT, projectRoot, { recursive: true });
+  tempProjectRoots.push(projectRoot);
+  return projectRoot;
+}
+
+export function readFixtureFile(
+  projectRoot: string,
+  segments: string[]
+): string {
+  return fs.readFileSync(getFixturePath(projectRoot, segments), 'utf8');
+}
+
+export async function compileAndroidMods(
+  projectRoot: string,
+  propsOverrides: Partial<JPushPluginProps> = {}
+): Promise<void> {
+  const config = withJPush(
+    createExpoConfig(),
+    createPluginProps(propsOverrides)
+  );
+
+  await compileModsAsync(config, {
+    projectRoot,
+    platforms: ['android'],
+  });
+}

--- a/plugin/__tests__/fixtures/android-project/android/app/build.gradle
+++ b/plugin/__tests__/fixtures/android-project/android/app/build.gradle
@@ -1,0 +1,182 @@
+apply plugin: "com.android.application"
+apply plugin: "org.jetbrains.kotlin.android"
+apply plugin: "com.facebook.react"
+
+def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
+
+/**
+ * This is the configuration block to customize your React Native Android app.
+ * By default you don't need to apply any configuration, just uncomment the lines you need.
+ */
+react {
+    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
+    reactNativeDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
+    hermesCommand = new File(["node", "--print", "require.resolve('hermes-compiler/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/hermesc/%OS-BIN%/hermesc"
+    codegenDir = new File(["node", "--print", "require.resolve('@react-native/codegen/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
+
+    enableBundleCompression = (findProperty('android.enableBundleCompression') ?: false).toBoolean()
+    // Use Expo CLI to bundle the app, this ensures the Metro config
+    // works correctly with Expo projects.
+    cliFile = new File(["node", "--print", "require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })"].execute(null, rootDir).text.trim())
+    bundleCommand = "export:embed"
+
+    /* Folders */
+     //   The root of your project, i.e. where "package.json" lives. Default is '../..'
+    // root = file("../../")
+    //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
+    // reactNativeDir = file("../../node_modules/react-native")
+    //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen
+    // codegenDir = file("../../node_modules/@react-native/codegen")
+
+    /* Variants */
+    //   The list of variants to that are debuggable. For those we're going to
+    //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
+    //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
+    // debuggableVariants = ["liteDebug", "prodDebug"]
+
+    /* Bundling */
+    //   A list containing the node command and its flags. Default is just 'node'.
+    // nodeExecutableAndArgs = ["node"]
+
+    //
+    //   The path to the CLI configuration file. Default is empty.
+    // bundleConfig = file(../rn-cli.config.js)
+    //
+    //   The name of the generated asset file containing your JS bundle
+    // bundleAssetName = "MyApplication.android.bundle"
+    //
+    //   The entry file for bundle generation. Default is 'index.android.js' or 'index.js'
+    // entryFile = file("../js/MyApplication.android.js")
+    //
+    //   A list of extra flags to pass to the 'bundle' commands.
+    //   See https://github.com/react-native-community/cli/blob/main/docs/commands.md#bundle
+    // extraPackagerArgs = []
+
+    /* Hermes Commands */
+    //   The hermes compiler command to run. By default it is 'hermesc'
+    // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
+    //
+    //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
+    // hermesFlags = ["-O", "-output-source-map"]
+
+    /* Autolinking */
+    autolinkLibrariesWithApp()
+}
+
+/**
+ * Set this to true in release builds to optimize the app using [R8](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization).
+ */
+def enableMinifyInReleaseBuilds = (findProperty('android.enableMinifyInReleaseBuilds') ?: false).toBoolean()
+
+/**
+ * The preferred build flavor of JavaScriptCore (JSC)
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US. Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
+
+android {
+    ndkVersion rootProject.ext.ndkVersion
+
+    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdk rootProject.ext.compileSdkVersion
+
+    namespace 'com.anonymous.mxjpushexpoandroid1aIhJx'
+    defaultConfig {
+        applicationId 'com.anonymous.mxjpushexpoandroid1aIhJx'
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0.0"
+
+        buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
+    }
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            def enableShrinkResources = findProperty('android.enableShrinkResourcesInReleaseBuilds') ?: 'false'
+            shrinkResources enableShrinkResources.toBoolean()
+            minifyEnabled enableMinifyInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            def enablePngCrunchInRelease = findProperty('android.enablePngCrunchInReleaseBuilds') ?: 'true'
+            crunchPngs enablePngCrunchInRelease.toBoolean()
+        }
+    }
+    packagingOptions {
+        jniLibs {
+            def enableLegacyPackaging = findProperty('expo.useLegacyPackaging') ?: 'false'
+            useLegacyPackaging enableLegacyPackaging.toBoolean()
+        }
+    }
+    androidResources {
+        ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:!CVS:!thumbs.db:!picasa.ini:!*~'
+    }
+}
+
+// Apply static values from `gradle.properties` to the `android.packagingOptions`
+// Accepts values in comma delimited lists, example:
+// android.packagingOptions.pickFirsts=/LICENSE,**/picasa.ini
+["pickFirsts", "excludes", "merges", "doNotStrip"].each { prop ->
+    // Split option: 'foo,bar' -> ['foo', 'bar']
+    def options = (findProperty("android.packagingOptions.$prop") ?: "").split(",");
+    // Trim all elements in place.
+    for (i in 0..<options.size()) options[i] = options[i].trim();
+    // `[] - ""` is essentially `[""].filter(Boolean)` removing all empty strings.
+    options -= ""
+
+    if (options.length > 0) {
+        println "android.packagingOptions.$prop += $options ($options.length)"
+        // Ex: android.packagingOptions.pickFirsts += '**/SCCS/**'
+        options.each {
+            android.packagingOptions[prop] += it
+        }
+    }
+}
+
+dependencies {
+    // The version of react-native is set by the React Native Gradle Plugin
+    implementation("com.facebook.react:react-android")
+
+    def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
+    def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
+    def isWebpAnimatedEnabled = (findProperty('expo.webp.animated') ?: "") == "true";
+
+    if (isGifEnabled) {
+        // For animated gif support
+        implementation("com.facebook.fresco:animated-gif:${expoLibs.versions.fresco.get()}")
+    }
+
+    if (isWebpEnabled) {
+        // For webp support
+        implementation("com.facebook.fresco:webpsupport:${expoLibs.versions.fresco.get()}")
+        if (isWebpAnimatedEnabled) {
+            // Animated webp support
+            implementation("com.facebook.fresco:animated-webp:${expoLibs.versions.fresco.get()}")
+        }
+    }
+
+    if (hermesEnabled.toBoolean()) {
+        implementation("com.facebook.react:hermes-android")
+    } else {
+        implementation jscFlavor
+    }
+}

--- a/plugin/__tests__/fixtures/android-project/android/app/src/main/AndroidManifest.xml
+++ b/plugin/__tests__/fixtures/android-project/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+  <uses-permission android:name="android.permission.VIBRATE"/>
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="https"/>
+    </intent>
+  </queries>
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false">
+    <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/plugin/__tests__/fixtures/android-project/android/build.gradle
+++ b/plugin/__tests__/fixtures/android-project/android/build.gradle
@@ -1,0 +1,24 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+  repositories {
+    google()
+    mavenCentral()
+  }
+  dependencies {
+    classpath('com.android.tools.build:gradle')
+    classpath('com.facebook.react:react-native-gradle-plugin')
+    classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
+  }
+}
+
+allprojects {
+  repositories {
+    google()
+    mavenCentral()
+    maven { url 'https://www.jitpack.io' }
+  }
+}
+
+apply plugin: "expo-root-project"
+apply plugin: "com.facebook.react.rootproject"

--- a/plugin/__tests__/fixtures/android-project/android/gradle.properties
+++ b/plugin/__tests__/fixtures/android-project/android/gradle.properties
@@ -1,0 +1,61 @@
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+org.gradle.parallel=true
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+
+# Enable AAPT2 PNG crunching
+android.enablePngCrunchInReleaseBuilds=true
+
+# Use this property to specify which architecture you want to build.
+# You can also override it from the CLI using
+# ./gradlew <task> -PreactNativeArchitectures=x86_64
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+
+# Use this property to enable support to the new architecture.
+# This will allow you to use TurboModules and the Fabric render in
+# your application. You should enable this flag either if you want
+# to write custom TurboModules/Fabric components OR use libraries that
+# are providing them.
+newArchEnabled=true
+
+# Use this property to enable or disable the Hermes JS engine.
+# If set to false, you will be using JSC instead.
+hermesEnabled=true
+
+# Use this property to enable edge-to-edge display support.
+# This allows your app to draw behind system bars for an immersive UI.
+# Note: Only works with ReactActivity and should not be used with custom Activity.
+edgeToEdgeEnabled=true
+
+# Enable GIF support in React Native images (~200 B increase)
+expo.gif.enabled=true
+# Enable webp support in React Native images (~85 KB increase)
+expo.webp.enabled=true
+# Enable animated webp support (~3.4 MB increase)
+# Disabled by default because iOS doesn't support animated webp
+expo.webp.animated=false
+
+# Enable network inspector
+EX_DEV_CLIENT_NETWORK_INSPECTOR=true
+
+# Use legacy packaging to compress native libraries in the resulting APK.
+expo.useLegacyPackaging=false

--- a/plugin/__tests__/fixtures/android-project/android/settings.gradle
+++ b/plugin/__tests__/fixtures/android-project/android/settings.gradle
@@ -1,0 +1,39 @@
+pluginManagement {
+  def reactNativeGradlePlugin = new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })")
+    }.standardOutput.asText.get().trim()
+  ).getParentFile().absolutePath
+  includeBuild(reactNativeGradlePlugin)
+  
+  def expoPluginsPath = new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })")
+    }.standardOutput.asText.get().trim(),
+    "../android/expo-gradle-plugin"
+  ).absolutePath
+  includeBuild(expoPluginsPath)
+}
+
+plugins {
+  id("com.facebook.react.settings")
+  id("expo-autolinking-settings")
+}
+
+extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
+  if (System.getenv('EXPO_USE_COMMUNITY_AUTOLINKING') == '1') {
+    ex.autolinkLibrariesFromCommand()
+  } else {
+    ex.autolinkLibrariesFromCommand(expoAutolinking.rnConfigCommand)
+  }
+}
+expoAutolinking.useExpoModules()
+
+rootProject.name = 'mx-jpush-expo-android-1aIhJx'
+
+expoAutolinking.useExpoVersionCatalog()
+
+include ':app'
+includeBuild(expoAutolinking.reactNativeGradlePlugin)

--- a/plugin/__tests__/iosFixture.ts
+++ b/plugin/__tests__/iosFixture.ts
@@ -1,8 +1,11 @@
 import { compileModsAsync } from 'expo/config-plugins';
 import * as fs from 'fs';
+import { createRequire } from 'module';
 import * as os from 'os';
 import * as path from 'path';
 import withJPush from '../src';
+import { JPushPluginProps } from '../src/types';
+import { createExpoConfig, createPluginProps } from './testProps';
 
 type PlistModule = {
   build: (value: Record<string, unknown>) => string;
@@ -42,12 +45,13 @@ type XcodeModule = {
   project: (filePath: string) => XcodeProject;
 };
 
-const expoPackageRoot = path.dirname(require.resolve('expo/package.json'));
-const plist = require(
-  require.resolve('@expo/plist', { paths: [expoPackageRoot] })
+const requireFromTests = createRequire(__filename);
+const expoPackageRoot = path.dirname(requireFromTests.resolve('expo/package.json'));
+const plist = requireFromTests(
+  requireFromTests.resolve('@expo/plist', { paths: [expoPackageRoot] })
 ).default as PlistModule;
-const xcode = require(
-  require.resolve('xcode', { paths: [expoPackageRoot] })
+const xcode = requireFromTests(
+  requireFromTests.resolve('xcode', { paths: [expoPackageRoot] })
 ) as XcodeModule;
 
 export const FIXTURE_ROOT = path.join(__dirname, 'fixtures', 'ios-project');
@@ -153,18 +157,13 @@ export function removeBridgingHeaderBuildSetting(projectRoot: string): void {
   fs.writeFileSync(pbxprojPath, nextContents);
 }
 
-export async function compileIosMods(projectRoot: string): Promise<void> {
+export async function compileIosMods(
+  projectRoot: string,
+  propsOverrides: Partial<JPushPluginProps> = {}
+): Promise<void> {
   const config = withJPush(
-    {
-      name: 'app',
-      slug: 'app',
-      version: '1.0.0',
-    },
-    {
-      appKey: 'test-app-key',
-      channel: 'test-channel',
-      packageName: 'com.example.test',
-    }
+    createExpoConfig(),
+    createPluginProps(propsOverrides)
   );
 
   await compileModsAsync(config, {

--- a/plugin/__tests__/nativeAndroidMods.test.ts
+++ b/plugin/__tests__/nativeAndroidMods.test.ts
@@ -1,0 +1,204 @@
+import {
+  ANDROID_MANIFEST_PATH,
+  APP_BUILD_GRADLE_PATH,
+  GRADLE_PROPERTIES_PATH,
+  PROJECT_BUILD_GRADLE_PATH,
+  SETTINGS_GRADLE_PATH,
+  compileAndroidMods,
+  createProjectRoot,
+  readFixtureFile,
+  registerAndroidFixtureLifecycleHooks,
+} from './androidFixture';
+
+registerAndroidFixtureLifecycleHooks();
+
+const countOccurrences = (source: string, needle: string): number =>
+  source.split(needle).length - 1;
+
+describe('native Android config mods', () => {
+  it('applies the baseline Android plugin flow to the fixture project', async () => {
+    const projectRoot = createProjectRoot();
+
+    await compileAndroidMods(projectRoot);
+
+    const androidManifest = readFixtureFile(projectRoot, ANDROID_MANIFEST_PATH);
+    const appBuildGradle = readFixtureFile(projectRoot, APP_BUILD_GRADLE_PATH);
+    const settingsGradle = readFixtureFile(projectRoot, SETTINGS_GRADLE_PATH);
+    const projectBuildGradle = readFixtureFile(
+      projectRoot,
+      PROJECT_BUILD_GRADLE_PATH
+    );
+    const gradleProperties = readFixtureFile(
+      projectRoot,
+      GRADLE_PROPERTIES_PATH
+    );
+
+    expect(androidManifest).toContain('android:name="JPUSH_CHANNEL"');
+    expect(androidManifest).toContain('android:value="${JPUSH_CHANNEL}"');
+    expect(androidManifest).toContain('android:name="JPUSH_APPKEY"');
+    expect(androidManifest).toContain('android:value="${JPUSH_APPKEY}"');
+
+    expect(settingsGradle).toContain("include ':jpush-react-native'");
+    expect(settingsGradle).toContain("include ':jcore-react-native'");
+
+    expect(appBuildGradle).toContain("implementation project(':jpush-react-native')");
+    expect(appBuildGradle).toContain("implementation project(':jcore-react-native')");
+    expect(appBuildGradle).toContain(
+      "implementation fileTree(include: ['*.jar','*.aar'], dir: 'libs')"
+    );
+    expect(appBuildGradle).toContain("abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'");
+    expect(appBuildGradle).toContain(
+      'JPUSH_PKGNAME: System.getenv("JPUSH_PKGNAME") ?: (project.findProperty("JPUSH_PKGNAME") ?: "com.example.test")'
+    );
+    expect(appBuildGradle).toContain(
+      'JPUSH_APPKEY: System.getenv("JPUSH_APP_KEY") ?: (project.findProperty("JPUSH_APP_KEY") ?: "")'
+    );
+    expect(appBuildGradle).toContain(
+      'JPUSH_CHANNEL: System.getenv("JPUSH_CHANNEL") ?: (project.findProperty("JPUSH_CHANNEL") ?: "")'
+    );
+    expect(appBuildGradle).not.toContain(
+      "implementation 'com.google.firebase:firebase-messaging:24.1.0'"
+    );
+    expect(appBuildGradle).not.toContain(
+      "apply plugin: 'com.google.gms.google-services'"
+    );
+    expect(projectBuildGradle).not.toContain(
+      "classpath 'com.google.gms:google-services:4.4.0'"
+    );
+    expect(gradleProperties).not.toContain('apmsInstrumentationEnabled=false');
+  });
+
+  it('adds vendor-specific Android integrations and keeps them idempotent', async () => {
+    const projectRoot = createProjectRoot();
+    const vendorChannels = {
+      huawei: { enabled: true },
+      fcm: { enabled: true },
+      meizu: { appId: 'mz-id', appKey: 'mz-key' },
+      xiaomi: { appId: 'xm-id', appKey: 'xm-key' },
+      oppo: {
+        appId: 'op-id',
+        appKey: 'op-key',
+        appSecret: 'op-sec',
+      },
+      vivo: { appId: 'vv-id', appKey: 'vv-key' },
+      honor: { appId: 'hr-id' },
+      nio: { appId: 'nio-id' },
+    };
+
+    await compileAndroidMods(projectRoot, { vendorChannels });
+
+    const onceAppBuildGradle = readFixtureFile(projectRoot, APP_BUILD_GRADLE_PATH);
+    const onceProjectBuildGradle = readFixtureFile(
+      projectRoot,
+      PROJECT_BUILD_GRADLE_PATH
+    );
+    const onceSettingsGradle = readFixtureFile(projectRoot, SETTINGS_GRADLE_PATH);
+    const onceGradleProperties = readFixtureFile(
+      projectRoot,
+      GRADLE_PROPERTIES_PATH
+    );
+
+    await compileAndroidMods(projectRoot, { vendorChannels });
+
+    const twiceAppBuildGradle = readFixtureFile(
+      projectRoot,
+      APP_BUILD_GRADLE_PATH
+    );
+    const twiceProjectBuildGradle = readFixtureFile(
+      projectRoot,
+      PROJECT_BUILD_GRADLE_PATH
+    );
+    const twiceSettingsGradle = readFixtureFile(
+      projectRoot,
+      SETTINGS_GRADLE_PATH
+    );
+    const twiceGradleProperties = readFixtureFile(
+      projectRoot,
+      GRADLE_PROPERTIES_PATH
+    );
+
+    expect(twiceAppBuildGradle).toBe(onceAppBuildGradle);
+    expect(twiceProjectBuildGradle).toBe(onceProjectBuildGradle);
+    expect(twiceSettingsGradle).toBe(onceSettingsGradle);
+    expect(twiceGradleProperties).toBe(onceGradleProperties);
+
+    expect(twiceProjectBuildGradle).toContain(
+      "maven { url 'https://developer.huawei.com/repo/' }"
+    );
+    expect(twiceProjectBuildGradle).toContain(
+      "maven { url 'https://developer.hihonor.com/repo' }"
+    );
+    expect(twiceProjectBuildGradle).toContain(
+      "classpath 'com.google.gms:google-services:4.4.0'"
+    );
+    expect(twiceProjectBuildGradle).toContain(
+      "classpath 'com.huawei.agconnect:agcp:1.9.3.302'"
+    );
+
+    expect(twiceAppBuildGradle).toContain(
+      "apply plugin: 'com.google.gms.google-services'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "apply plugin: 'com.huawei.agconnect'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'com.huawei.hms:push:6.13.0.300'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'com.google.firebase:firebase-messaging:24.1.0'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'cn.jiguang.sdk.plugin:meizu:5.9.0'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'cn.jiguang.sdk.plugin:xiaomi:5.9.0'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'cn.jiguang.sdk.plugin:oppo:5.9.0'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'cn.jiguang.sdk.plugin:vivo:5.9.0'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'cn.jiguang.sdk.plugin:honor:5.9.0'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      "implementation 'cn.jiguang.sdk.plugin:nio:5.9.0'"
+    );
+    expect(twiceAppBuildGradle).toContain(
+      'MEIZU_APPKEY: System.getenv("JPUSH_MEIZU_APP_KEY") ?: (project.findProperty("JPUSH_MEIZU_APP_KEY") ?: "")'
+    );
+    expect(twiceAppBuildGradle).toContain(
+      'XIAOMI_APPKEY: System.getenv("JPUSH_XIAOMI_APP_KEY") ?: (project.findProperty("JPUSH_XIAOMI_APP_KEY") ?: "")'
+    );
+    expect(twiceAppBuildGradle).toContain('OPPO_APPSECRET:');
+    expect(twiceAppBuildGradle).toContain('JPUSH_OPPO_APP_SECRET');
+    expect(twiceAppBuildGradle).toContain(
+      'VIVO_APPID: System.getenv("JPUSH_VIVO_APP_ID") ?: (project.findProperty("JPUSH_VIVO_APP_ID") ?: "")'
+    );
+    expect(twiceAppBuildGradle).toContain(
+      'HONOR_APPID: System.getenv("JPUSH_HONOR_APP_ID") ?: (project.findProperty("JPUSH_HONOR_APP_ID") ?: "")'
+    );
+    expect(twiceAppBuildGradle).toContain(
+      'NIO_APPID: System.getenv("JPUSH_NIO_APP_ID") ?: (project.findProperty("JPUSH_NIO_APP_ID") ?: "")'
+    );
+
+    expect(twiceGradleProperties).toContain('apmsInstrumentationEnabled=false');
+
+    expect(
+      countOccurrences(twiceSettingsGradle, "include ':jpush-react-native'")
+    ).toBe(1);
+    expect(
+      countOccurrences(
+        twiceProjectBuildGradle,
+        "classpath 'com.google.gms:google-services:4.4.0'"
+      )
+    ).toBe(1);
+    expect(
+      countOccurrences(
+        twiceAppBuildGradle,
+        "apply plugin: 'com.huawei.agconnect'"
+      )
+    ).toBe(1);
+  });
+});

--- a/plugin/__tests__/nativeIosAppDelegate.test.ts
+++ b/plugin/__tests__/nativeIosAppDelegate.test.ts
@@ -1,0 +1,82 @@
+import * as fs from 'fs';
+import {
+  APP_DELEGATE_PATH,
+  compileIosMods,
+  createProjectRoot,
+  getFixturePath,
+  registerIosFixtureLifecycleHooks,
+} from './iosFixture';
+
+registerIosFixtureLifecycleHooks();
+
+const countOccurrences = (source: string, needle: string): number =>
+  source.split(needle).length - 1;
+
+describe('native iOS AppDelegate mod', () => {
+  it('injects JPush registration, APNs callbacks, and delegate handlers', async () => {
+    const projectRoot = createProjectRoot();
+
+    await compileIosMods(projectRoot);
+
+    const appDelegate = fs.readFileSync(
+      getFixturePath(projectRoot, APP_DELEGATE_PATH),
+      'utf8'
+    );
+
+    expect(appDelegate).toContain('import UserNotifications');
+    expect(appDelegate).toContain(
+      'JPUSHService.register(forRemoteNotificationConfig: entity, delegate: self)'
+    );
+    expect(appDelegate).toContain('JPUSHService.setup(withOption: launchOptions,');
+    expect(appDelegate).toContain(
+      'didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data'
+    );
+    expect(appDelegate).toContain(
+      'didFailToRegisterForRemoteNotificationsWithError error: Error'
+    );
+    expect(appDelegate).toContain('extension AppDelegate: JPUSHRegisterDelegate');
+    expect(appDelegate).toContain(
+      'name: NSNotification.Name("J_APNS_NOTIFICATION_ARRIVED_EVENT")'
+    );
+    expect(appDelegate).toContain(
+      'name: NSNotification.Name("J_CUSTOM_NOTIFICATION_EVENT")'
+    );
+  });
+
+  it('keeps AppDelegate injection idempotent across repeated compiles', async () => {
+    const projectRoot = createProjectRoot();
+
+    await compileIosMods(projectRoot);
+    const onceCompiled = fs.readFileSync(
+      getFixturePath(projectRoot, APP_DELEGATE_PATH),
+      'utf8'
+    );
+
+    await compileIosMods(projectRoot);
+    const twiceCompiled = fs.readFileSync(
+      getFixturePath(projectRoot, APP_DELEGATE_PATH),
+      'utf8'
+    );
+
+    expect(twiceCompiled).toBe(onceCompiled);
+    expect(countOccurrences(twiceCompiled, 'import UserNotifications')).toBe(1);
+    expect(
+      countOccurrences(
+        twiceCompiled,
+        'JPUSHService.register(forRemoteNotificationConfig: entity, delegate: self)'
+      )
+    ).toBe(1);
+    expect(
+      countOccurrences(
+        twiceCompiled,
+        'didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data'
+      )
+    ).toBe(1);
+    expect(
+      countOccurrences(
+        twiceCompiled,
+        'extension AppDelegate: JPUSHRegisterDelegate'
+      )
+    ).toBe(1);
+  });
+});

--- a/plugin/__tests__/nativeIosSmoke.test.ts
+++ b/plugin/__tests__/nativeIosSmoke.test.ts
@@ -24,8 +24,8 @@ describe('native iOS fixture harness', () => {
 
     expect(appDelegate).toContain('import UserNotifications');
     expect(appDelegate).toContain('JPUSHService.setup');
-    expect(infoPlist.JPUSH_APPKEY).toBe('test-app-key');
-    expect(infoPlist.JPUSH_CHANNEL).toBe('test-channel');
+    expect(infoPlist.JPUSH_APPKEY).toBe('tp-key');
+    expect(infoPlist.JPUSH_CHANNEL).toBe('tp-chan');
     expect(infoPlist.UIBackgroundModes).toEqual(
       expect.arrayContaining(['fetch', 'remote-notification'])
     );

--- a/plugin/__tests__/testProps.ts
+++ b/plugin/__tests__/testProps.ts
@@ -1,0 +1,27 @@
+import { ExpoConfig } from 'expo/config';
+import { JPushPluginProps } from '../src/types';
+
+export const TEST_EXPO_CONFIG: ExpoConfig = {
+  name: 'app',
+  slug: 'app',
+  version: '1.0.0',
+};
+
+export const TEST_PLUGIN_PROPS: JPushPluginProps = {
+  appKey: 'tp-key',
+  channel: 'tp-chan',
+  packageName: 'com.example.test',
+};
+
+export function createExpoConfig(): ExpoConfig {
+  return { ...TEST_EXPO_CONFIG };
+}
+
+export function createPluginProps(
+  overrides: Partial<JPushPluginProps> = {}
+): JPushPluginProps {
+  return {
+    ...TEST_PLUGIN_PROPS,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- add an Android fixture harness for compileModsAsync-based regression coverage
- add focused AppDelegate.swift regression tests for initialization, callbacks, and idempotency
- extend native fixture tests to cover baseline Android output and vendor-specific injections

## Validation
- npm run build
- npm run lint
- npm test -- --runInBand