### PR TITLE
docs(readme): redesign project readme for clearer OSS presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+历史版本更新从 README 中拆出，便于首页专注接入说明与使用导航。
+
+## v1.2.2 (2026-03-08)
+
+- 修复 `JPUSH_PKGNAME` 依赖 `applicationId` 声明顺序的问题
+- `JPUSH_PKGNAME` 改为按 `环境变量 -> gradle.properties -> 插件 packageName` 回退
+
+## v1.2.1 (2026-03-08)
+
+- Android `manifestPlaceholders` 改为在 Gradle 构建时读取环境变量或 `gradle.properties`
+- 不再把 `JPUSH_APPKEY`、`JPUSH_CHANNEL` 和厂商密钥明文写入 `android/app/build.gradle`
+- iOS 改为从 `Info.plist` 读取 JPush 初始化参数，不再把这些值直接注入 `AppDelegate.swift`
+- README 更新为 `app.config.ts + 环境变量` 的推荐用法
+
+## v1.1.0 (2025-12-17)
+
+**🎉 完整支持 Android 厂商通道**
+
+- ✨ 新增完整的 Android 厂商通道支持（华为、FCM、小米、OPPO、VIVO、魅族、荣耀、蔚来）
+- ✨ 自动配置厂商通道 SDK 依赖（JPush 5.9.0）
+- ✨ 自动配置 `manifestPlaceholders`（包括 `JPUSH_PKGNAME`）
+- ✨ 自动配置 NDK `abiFilters`
+- ✨ 自动配置华为和 FCM 的 `apply plugin` 语句
+- ✨ 自动配置 project/build.gradle（Maven 仓库和 classpath）
+- ✨ 新增 `packageName` 必填配置项
+- 📝 完善厂商通道配置文档，添加极光官方文档链接
+- 📝 添加应用签名配置说明（华为、荣耀、蔚来必需）
+- 🔧 优化代码结构，移除手动下载 aar 的要求
+
+## v1.0.2 (2024-09-27)
+
+> 📖 **参考文章**：[Expo SDK 53+ 集成极光推送 iOS Swift](https://juejin.cn/post/7554288083597885467)
+
+- ✨ 支持 Expo SDK 53+ 和 React Native 0.79.5+
+- ✨ 添加 iOS Swift/OC 混编支持（Bridging Header 配置）
+- ✨ 更新依赖版本：jpush-react-native@3.1.9, jcore-react-native@2.3.0
+- ✨ 添加推送权限说明配置（NSUserTrackingUsageDescription, NSMicrophoneUsageDescription）
+- 🐛 修复 iOS 新架构下的兼容性问题
+- 📝 更新文档，添加最新集成指南
+
+## v1.0.1
+
+> 📖 **参考文章**：[JPush 集成 Expo](https://juejin.cn/post/7423235127716659239)
+
+- 初始版本发布
+- 支持基础的 iOS 和 Android 集成

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,10 +2,17 @@
 
 本文档说明如何开发和维护 mx-jpush-expo 插件。
 
+## 文档导航
+
+- 接入与使用说明：[`README.md`](./README.md)
+- 插件内部结构：[`plugin/README.md`](./plugin/README.md)
+- 历史版本更新：[`CHANGELOG.md`](./CHANGELOG.md)
+
 ## 环境要求
 
-- Node.js >= 16
-- npm >= 7
+- Node.js >= 18.18.0
+- Expo SDK 53 作为仓库开发基线
+- 推荐 pnpm 10 或 npm 10+
 - TypeScript >= 5.0
 
 ## 安装依赖
@@ -14,13 +21,20 @@
 npm install
 ```
 
+或使用：
+
+```bash
+pnpm install
+```
+
 ## 项目结构
 
 插件采用 TypeScript 开发，遵循 Expo 官方最佳实践：
 
 - **源码目录**: `plugin/src/` - TypeScript 源文件
 - **构建目录**: `plugin/build/` - 编译后的 JavaScript 文件
-- **测试目录**: `plugin/__tests__/` - Jest 单元测试
+- **测试目录**: `plugin/__tests__/` - Jest 单元测试与 iOS fixture 回归测试
+- **CI 配置**: `.github/workflows/ci.yml` - build / test / lint 质量检查
 
 ## 开发流程
 
@@ -28,7 +42,7 @@ npm install
 
 所有源码位于 `plugin/src/` 目录：
 
-```
+```text
 plugin/src/
 ├── index.ts           # 主入口
 ├── types.ts           # 类型定义
@@ -52,14 +66,24 @@ npm run build
 
 ```bash
 # 运行所有测试
-npm test
+npm test -- --runInBand
 
 # 监听模式
 npm test -- --watch
 
 # 生成覆盖率报告
 npm test -- --coverage
+
+# 运行 lint
+npm run lint
 ```
+
+当前主线的测试重点：
+
+- `withJPush.test.ts`：参数校验与插件入口基础行为
+- `nativeIosSmoke.test.ts`：iOS 主流程 smoke
+- `nativeIosMods.test.ts`：`Info.plist` 与 Bridging Header 的 fixture 回归测试
+- Android 与 `AppDelegate` 的细粒度 fixture 覆盖会继续在后续 PR 中补齐
 
 ### 4. 清理
 
@@ -144,6 +168,8 @@ const withMyPlugin: ConfigPlugin<MyPluginProps> = (config, props) => {
 
 ## 测试策略
 
+当前仓库更偏向“参数校验 + fixture 回归测试”的组合，而不是只做纯函数单测。
+
 ### 单元测试
 
 测试配置转换逻辑：
@@ -215,6 +241,16 @@ describe('withMyPlugin', () => {
 
 5. 验证生成的原生代码
 
+### 仓库内回归测试
+
+除了业务项目联调，这个仓库还通过 `compileModsAsync` 驱动最小 iOS fixture，直接验证 `Info.plist`、Bridging Header 等原生输出。
+
+这种方式的价值在于：
+
+- 能覆盖正则锚点与模板兼容性
+- 能验证重复执行时的幂等行为
+- 比只检查 helper 返回值更接近真实 `expo prebuild`
+
 ## 发布流程
 
 ### 1. 更新版本
@@ -234,7 +270,8 @@ npm run build
 ### 3. 测试
 
 ```bash
-npm test
+npm test -- --runInBand
+npm run lint
 ```
 
 ### 4. 发布
@@ -268,6 +305,10 @@ A: 检查：
 2. `plugin/build/` 目录是否存在
 3. 运行 `npm run build` 重新构建
 4. 使用 `--clean` 标志重新 prebuild
+
+### Q: 为什么文档拆成了多个 Markdown 文件？
+
+A: 根目录 `README.md` 主要面向接入者，`DEVELOPMENT.md` 面向仓库维护者，`plugin/README.md` 面向插件内部结构说明。这样可以在不删除原有信息的前提下，把内容分层并保持首页可读性。
 
 ## 参考资源
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - [快速开始](#快速开始)
 - [推荐配置](#推荐配置)
 - [环境变量与厂商通道](#环境变量与厂商通道)
+- [配置说明](#配置说明)
 - [插件会修改哪些原生文件](#插件会修改哪些原生文件)
 - [如何验证生成结果](#如何验证生成结果)
 - [常见问题](#常见问题)
@@ -191,20 +192,37 @@ JPUSH_XIAOMI_APP_ID=your-xiaomi-app-id
 JPUSH_XIAOMI_APP_KEY=your-xiaomi-app-key
 ```
 
+也可以把这些值写到 `android/gradle.properties`，构建时会通过 `project.findProperty(...)` 读取。
+
+## 配置说明
+
+- `appKey`、`channel`、`packageName` 仍然是插件必填项，因为 iOS 注入代码和参数校验发生在 Expo 配置阶段。
+- iOS 现在改为从 `Info.plist` 读取 `JPUSH_APPKEY`、`JPUSH_CHANNEL` 和 `JPUSH_APS_FOR_PRODUCTION`，不再把这些值直接拼接进 `AppDelegate.swift`。
+- 这能避免源码层的明文注入，但不能把它们变成客户端不可见的“秘密”，因为 JPush 初始化参数最终仍会出现在打包产物里。
+- Android 侧生成的 `manifestPlaceholders` 不再把这些值写死到 `build.gradle` 中。
+- `JPUSH_PKGNAME` 现在按 `System.getenv("JPUSH_PKGNAME") -> project.findProperty("JPUSH_PKGNAME") -> 插件收到的 packageName` 回退，不再依赖 `applicationId` 的声明顺序。
+- `vendorChannels` 的作用是决定要注入哪些厂商 SDK 和哪些占位符；真正的厂商密钥建议通过环境变量或 `gradle.properties` 提供。
+- 厂商通道配置是可选的，只需配置你实际使用的厂商。
+- 厂商通道插件版本：**5.9.0**。
+
 ### 厂商通道额外要求
 
 | 厂商 | 额外文件 | 签名要求 | 说明 |
 | --- | --- | --- | --- |
-| 华为 | `agconnect-services.json` | 需要 | 需配置 SHA256 指纹 |
-| FCM | `google-services.json` | 不需要 | 需在 Firebase 控制台申请 |
-| 荣耀 | 无 | 需要 | 需配置 SHA256 指纹 |
-| 蔚来 | 无 | 需要 | 需配置应用签名 |
-| 小米 | 无 | 不需要 | 仅需 AppId / AppKey |
-| OPPO | 无 | 不需要 | 仅需 AppId / AppKey / AppSecret |
-| VIVO | 无 | 不需要 | 仅需 AppId / AppKey |
-| 魅族 | 无 | 不需要 | 仅需 AppId / AppKey |
+| **华为** | `agconnect-services.json` | ✅ **必需** | 需在华为开发者联盟申请，配置 SHA256 指纹 |
+| **FCM** | `google-services.json` | ❌ | 需在 Firebase 控制台申请 |
+| **荣耀** | 无 | ✅ **必需** | 需在荣耀开发者平台配置 SHA256 指纹 |
+| **蔚来** | 无 | ✅ **必需** | 需在蔚来开发者平台配置应用签名 |
+| **小米** | 无 | ❌ | 仅需 AppId 和 AppKey |
+| **OPPO** | 无 | ❌ | 仅需 AppKey、AppId 和 AppSecret |
+| **VIVO** | 无 | ❌ | 仅需 AppKey 和 AppId |
+| **魅族** | 无 | ❌ | 仅需 AppKey 和 AppId |
 
 官方参数说明见：[极光推送 Android 厂商通道参数获取](https://docs.jiguang.cn/jpush/client/Android/android_3rd_param)
+
+**配置文件位置**：
+
+- 将 `agconnect-services.json`（华为）或 `google-services.json`（FCM）放到 `android/app/` 目录
 
 ### Android 签名配置示例
 
@@ -340,31 +358,38 @@ npm run lint
 
 ```text
 mx-jpush-expo/
-├── app.plugin.js
-├── plugin/
-│   ├── src/
-│   │   ├── index.ts
-│   │   ├── types.ts
-│   │   ├── ios/
-│   │   │   ├── infoPlist.ts
-│   │   │   ├── appDelegate.ts
-│   │   │   └── bridgingHeader.ts
-│   │   ├── android/
-│   │   │   ├── androidManifest.ts
-│   │   │   ├── appBuildGradle.ts
-│   │   │   ├── projectBuildGradle.ts
-│   │   │   ├── settingsGradle.ts
-│   │   │   └── gradleProperties.ts
-│   │   └── utils/
-│   │       └── config.ts
-│   ├── __tests__/
-│   │   ├── fixtures/
+├── app.plugin.js                 # 主入口文件
+├── plugin/                       # 插件源码和构建
+│   ├── src/                      # TypeScript 源码
+│   │   ├── index.ts              # 插件主入口
+│   │   ├── types.ts              # 类型定义和参数校验
+│   │   ├── utils/                # 工具模块
+│   │   │   ├── config.ts         # 全局配置管理
+│   │   │   ├── codeValidator.ts  # 注入结果校验
+│   │   │   └── generateCode.ts   # 原生代码注入工具
+│   │   ├── ios/                  # iOS 平台配置
+│   │   │   ├── index.ts          # iOS 配置集成入口
+│   │   │   ├── infoPlist.ts      # Info.plist 配置
+│   │   │   ├── appDelegate.ts    # AppDelegate 实现配置
+│   │   │   └── bridgingHeader.ts # Swift/OC 桥接头文件配置
+│   │   └── android/              # Android 平台配置
+│   │       ├── index.ts          # Android 配置集成入口
+│   │       ├── androidManifest.ts # AndroidManifest.xml 配置
+│   │       ├── appBuildGradle.ts # app/build.gradle 配置
+│   │       ├── projectBuildGradle.ts # project/build.gradle 配置
+│   │       ├── settingsGradle.ts # settings.gradle 配置
+│   │       └── gradleProperties.ts # gradle.properties 配置
+│   ├── build/                    # 编译后的 JavaScript 文件（npm 发布）
+│   ├── __tests__/                # 测试目录
+│   │   ├── fixtures/             # 原生工程 fixture
 │   │   │   └── ios-project/
-│   │   ├── iosFixture.ts
-│   │   └── *.test.ts
-│   └── build/
-├── .github/workflows/ci.yml
-└── README.md
+│   │   ├── iosFixture.ts         # iOS fixture helper
+│   │   └── *.test.ts             # Jest 用例
+│   ├── tsconfig.json             # TypeScript 配置
+│   └── jest.config.js            # Jest 测试配置
+├── .github/workflows/ci.yml      # CI 质量检查
+├── CHANGELOG.md                  # 历史更新日志
+└── README.md                     # 项目说明
 ```
 
 插件内部说明见 [plugin/README.md](./plugin/README.md)。
@@ -376,10 +401,15 @@ mx-jpush-expo/
 - 补齐 iOS fixture-based 原生回归测试
 - 加入 ESLint 与 CI 质量闭环
 - 对齐 Expo SDK 53 的版本声明与仓库开发基线
+- 历史版本更新已整理到 [CHANGELOG.md](./CHANGELOG.md)
 
 ## 致谢与许可
 
-感谢以下资料与实现思路的启发：
+感谢以下掘金文章作者的技术分享：
+
+- [@折七](https://juejin.cn/user/7423235127716659239) - JPush 集成 Expo 基础方案
+
+同时也感谢以下资料与实现思路的启发：
 
 - [JPush 集成 Expo](https://juejin.cn/post/7423235127716659239)
 - [Expo SDK 53+ 集成极光推送 iOS Swift](https://juejin.cn/post/7554288083597885467)

--- a/README.md
+++ b/README.md
@@ -347,6 +347,12 @@ npm run test -- --runInBand
 npm run lint
 ```
 
+相关文档：
+
+- 开发与维护流程见 [`DEVELOPMENT.md`](./DEVELOPMENT.md)
+- 插件内部结构见 [`plugin/README.md`](./plugin/README.md)
+- 历史版本更新见 [`CHANGELOG.md`](./CHANGELOG.md)
+
 ### 测试覆盖重点
 
 - 参数校验与插件入口 smoke

--- a/README.md
+++ b/README.md
@@ -121,27 +121,27 @@ export default ({ config }: ConfigContext): ExpoConfig => {
             huawei: { enabled: true },
             fcm: { enabled: true },
             xiaomi: {
-              appId: process.env.JPUSH_XIAOMI_APP_ID,
-              appKey: process.env.JPUSH_XIAOMI_APP_KEY,
+              appId: process.env.JPUSH_XIAOMI_APP_ID ?? '',
+              appKey: process.env.JPUSH_XIAOMI_APP_KEY ?? '',
             },
             oppo: {
-              appId: process.env.JPUSH_OPPO_APP_ID,
-              appKey: process.env.JPUSH_OPPO_APP_KEY,
-              appSecret: process.env.JPUSH_OPPO_APP_SECRET,
+              appId: process.env.JPUSH_OPPO_APP_ID ?? '',
+              appKey: process.env.JPUSH_OPPO_APP_KEY ?? '',
+              appSecret: process.env.JPUSH_OPPO_APP_SECRET ?? '',
             },
             vivo: {
-              appId: process.env.JPUSH_VIVO_APP_ID,
-              appKey: process.env.JPUSH_VIVO_APP_KEY,
+              appId: process.env.JPUSH_VIVO_APP_ID ?? '',
+              appKey: process.env.JPUSH_VIVO_APP_KEY ?? '',
             },
             meizu: {
-              appId: process.env.JPUSH_MEIZU_APP_ID,
-              appKey: process.env.JPUSH_MEIZU_APP_KEY,
+              appId: process.env.JPUSH_MEIZU_APP_ID ?? '',
+              appKey: process.env.JPUSH_MEIZU_APP_KEY ?? '',
             },
             honor: {
-              appId: process.env.JPUSH_HONOR_APP_ID,
+              appId: process.env.JPUSH_HONOR_APP_ID ?? '',
             },
             nio: {
-              appId: process.env.JPUSH_NIO_APP_ID,
+              appId: process.env.JPUSH_NIO_APP_ID ?? '',
             },
           },
         },
@@ -206,6 +206,49 @@ JPUSH_XIAOMI_APP_KEY=your-xiaomi-app-key
 
 官方参数说明见：[极光推送 Android 厂商通道参数获取](https://docs.jiguang.cn/jpush/client/Android/android_3rd_param)
 
+### Android 签名配置示例
+
+华为、荣耀、蔚来等厂商通道对应用签名更敏感，建议显式配置 release 签名，而不是只依赖默认 debug 签名。
+
+```gradle
+android {
+    ...
+    signingConfigs {
+        release {
+            storeFile file("release.keystore")
+            storePassword "your_store_password"
+            keyAlias "your_key_alias"
+            keyPassword "your_key_password"
+        }
+    }
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+            ...
+        }
+    }
+}
+```
+
+建议把密码等字段放到 `gradle.properties`，不要直接提交到代码仓库：
+
+```gradle
+// 在 gradle.properties 中配置（不要提交到 Git）
+RELEASE_STORE_PASSWORD=your_store_password
+RELEASE_KEY_PASSWORD=your_key_password
+RELEASE_KEY_ALIAS=your_key_alias
+
+// 在 build.gradle 中读取
+signingConfigs {
+    release {
+        storeFile file("release.keystore")
+        storePassword project.hasProperty('RELEASE_STORE_PASSWORD') ? RELEASE_STORE_PASSWORD : ''
+        keyAlias project.hasProperty('RELEASE_KEY_ALIAS') ? RELEASE_KEY_ALIAS : ''
+        keyPassword project.hasProperty('RELEASE_KEY_PASSWORD') ? RELEASE_KEY_PASSWORD : ''
+    }
+}
+```
+
 ## 插件会修改哪些原生文件
 
 | 平台 | 文件 | 作用 |
@@ -261,6 +304,19 @@ manifestPlaceholders = [
 
 如果你遇到类似 `com.android.tools.build:gradle is no set in the build.gradle file` 的错误，需要检查业务项目自己的 `android/build.gradle` 与 Expo 版本是否匹配。这不是本插件主动引入的行为变更。
 
+### iOS 推送证书或注册异常怎么排查？
+
+- 检查推送证书是否过期，以及开发 / 生产环境是否匹配
+- 检查 Bundle ID 是否与极光控制台配置完全一致
+- 检查推送权限是否已正确申请
+- 如果是冷启动通知异常，优先检查监听器与 JPush 初始化顺序
+
+### 厂商通道推送失败怎么排查？
+
+- 华为 / 荣耀 / 蔚来：先确认签名或 SHA256 指纹配置正确
+- 所有厂商：确认 AppId / AppKey / AppSecret 是否填写正确
+- 华为 / FCM：确认 `agconnect-services.json` / `google-services.json` 已放到 `android/app/`
+
 ### 直接改 `node_modules/mx-jpush-expo` 可以吗？
 
 不建议。重装依赖后会丢失，正式方式建议使用 `pnpm patch mx-jpush-expo` 或维护自己的 fork。
@@ -275,10 +331,10 @@ npm run lint
 
 ### 测试覆盖重点
 
+- 参数校验与插件入口 smoke
 - iOS `Info.plist` 合并与 Bridging Header 创建 / 幂等
-- iOS `AppDelegate.swift` 注入与幂等
-- Android `Manifest`、Gradle、Settings 和 `gradle.properties` 原生输出
-- fixture-based 回归测试，确保 `compileModsAsync` 输出稳定
+- 当前主线以 iOS fixture-based 回归测试为主
+- Android 原生输出和 `AppDelegate` 细粒度回归测试会在后续 PR 中继续补齐
 
 ## 项目结构
 
@@ -300,10 +356,11 @@ mx-jpush-expo/
 │   │   │   ├── settingsGradle.ts
 │   │   │   └── gradleProperties.ts
 │   │   └── utils/
+│   │       └── config.ts
 │   ├── __tests__/
 │   │   ├── fixtures/
+│   │   │   └── ios-project/
 │   │   ├── iosFixture.ts
-│   │   ├── androidFixture.ts
 │   │   └── *.test.ts
 │   └── build/
 ├── .github/workflows/ci.yml
@@ -316,7 +373,7 @@ mx-jpush-expo/
 
 - iOS `UIBackgroundModes` 改为合并写入，不再覆盖宿主已有后台模式
 - Swift `Bridging Header` 支持优先复用、缺失自动创建，并保持幂等
-- 补齐 iOS / Android fixture-based 原生回归测试
+- 补齐 iOS fixture-based 原生回归测试
 - 加入 ESLint 与 CI 质量闭环
 - 对齐 Expo SDK 53 的版本声明与仓库开发基线
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,103 @@
-# MX-JPUSH-Expo
-expo接入JPUSH脚本
+# MX-JPush-Expo
 
-> 📚 **本项目基于以下掘金文章开发和更新：**
-> - [JPush 集成 Expo](https://juejin.cn/post/7423235127716659239) - 基础集成方案
-> - [Expo SDK 53+ 集成极光推送 iOS Swift](https://juejin.cn/post/7554288083597885467) - 最新 Swift 版本实现
-> - [JPush-expo-config-plugin](https://github.com/RunoMeow/jpush-expo-config-plugin) - 参考实现
+<p align="center">
+  一个面向 <strong>Expo prebuild / Dev Client</strong> 的 JPush Config Plugin。<br />
+  自动注入 iOS / Android 原生配置，并支持主流 Android 厂商通道。
+</p>
 
-## 工作原理
-由于极光推送不支持`expo`模式，因此采用如下方式：
-```text
-`prebuild`为裸工作流 -> 代码注入
+<p align="center">
+  <a href="https://www.npmjs.com/package/mx-jpush-expo"><img alt="npm version" src="https://img.shields.io/npm/v/mx-jpush-expo?logo=npm&label=npm"></a>
+  <a href="https://github.com/konodioda727/JPush-Expo/actions/workflows/ci.yml"><img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/konodioda727/JPush-Expo/ci.yml?branch=main&logo=githubactions&label=CI"></a>
+  <a href="https://github.com/konodioda727/JPush-Expo/blob/main/LICENSE"><img alt="license" src="https://img.shields.io/github/license/konodioda727/JPush-Expo"></a>
+  <img alt="Expo SDK 53+" src="https://img.shields.io/badge/Expo%20SDK-53%2B-000020?logo=expo">
+  <img alt="Node >=18.18" src="https://img.shields.io/badge/Node-%3E%3D18.18-339933?logo=node.js&logoColor=white">
+</p>
+
+> [!IMPORTANT]
+> JPush 不支持 Expo Go。本项目面向 `expo prebuild` 后的原生工程，适用于 Dev Client 或原生构建流程。
+
+> [!TIP]
+> 本项目持续参考并吸收以下资料：<br>
+> [JPush 集成 Expo](https://juejin.cn/post/7423235127716659239) /<br>
+> [Expo SDK 53+ 集成极光推送 iOS Swift](https://juejin.cn/post/7554288083597885467) /<br>
+> [RunoMeow/jpush-expo-config-plugin](https://github.com/RunoMeow/jpush-expo-config-plugin)
+
+## 目录
+
+- [为什么使用它](#为什么使用它)
+- [支持矩阵](#支持矩阵)
+- [快速开始](#快速开始)
+- [推荐配置](#推荐配置)
+- [环境变量与厂商通道](#环境变量与厂商通道)
+- [插件会修改哪些原生文件](#插件会修改哪些原生文件)
+- [如何验证生成结果](#如何验证生成结果)
+- [常见问题](#常见问题)
+- [开发与测试](#开发与测试)
+- [项目结构](#项目结构)
+- [最近更新](#最近更新)
+- [致谢与许可](#致谢与许可)
+
+## 为什么使用它
+
+`mx-jpush-expo` 把 Expo 项目接入 JPush 时最容易反复手改的原生步骤，收敛成一次 `expo prebuild`：
+
+- 自动写入 iOS `Info.plist` 的 JPush 配置和后台模式
+- 自动注入 iOS `AppDelegate.swift` 的 JPush 初始化与回调代码
+- 自动复用或创建 Swift `Bridging Header`
+- 自动修改 Android `AndroidManifest.xml`、`build.gradle`、`settings.gradle`
+- 支持华为、FCM、小米、OPPO、VIVO、魅族、荣耀、蔚来等厂商通道注入
+
+适合这些场景：
+
+- 你使用 Expo，但需要 JPush 和厂商通道能力
+- 你希望把原生改动交给 Config Plugin 管理，而不是手改生成代码
+- 你需要在 CI / 团队协作里稳定复现 `prebuild` 输出
+
+## 支持矩阵
+
+| 项目 | 版本 |
+| --- | --- |
+| Expo SDK | `53+` |
+| 仓库开发基线 | `Expo SDK 53` |
+| React Native | `0.76.9` |
+| Node.js | `>= 18.18.0` |
+| `jpush-react-native` | `3.1.9` |
+| `jcore-react-native` | `2.3.0` |
+
+## 快速开始
+
+### 1. 安装依赖
+
+```bash
+npm install mx-jpush-expo
+npm install jpush-react-native@3.1.9 jcore-react-native@^2.3.0
 ```
 
-## 版本要求
-- Expo SDK: 53+
-- 仓库开发基线: Expo SDK 53
-- React Native: 0.76.9（Expo SDK 53 基线版本，由 Expo 锁定）
-- Node.js: 18.18+（仓库开发环境）
-- jpush-react-native: 3.1.9
-- jcore-react-native: 2.3.0
+或使用 `pnpm`：
 
-## 使用方式
-
-### 1.下载
-- 插件下载：
 ```bash
-npm i mx-jpush-expo
-```
-- `jpush`依赖包 `jpush-react-native` 和 `jcore-react-native` 下载（推荐使用指定版本）
-```bash
-npm install jpush-react-native@3.1.9 jcore-react-native@^2.3.0 --save
-# 或使用 pnpm
+pnpm add mx-jpush-expo
 pnpm add jpush-react-native@3.1.9 jcore-react-native@^2.3.0
 ```
 
-### 2.集成
-推荐使用 `app.config.ts`，并把 Android 端的敏感值交给环境变量或 `gradle.properties`。这样 `expo prebuild` 生成的 `android/app/build.gradle` 不会再写入明文。
+### 2. 配置插件
 
-#### 推荐配置
+推荐使用 `app.config.ts`，并把 Android 的敏感值交给环境变量或 `gradle.properties`。
+
+### 3. 生成原生工程
+
+```bash
+npx expo prebuild
+```
+
+只刷新 Android：
+
+```bash
+npx expo prebuild -p android
+```
+
+## 推荐配置
+
 ```ts
 import type { ConfigContext, ExpoConfig } from 'expo/config';
 import 'dotenv/config';
@@ -47,87 +107,79 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
   return {
     ...config,
-    plugins: (config.plugins || []).map(plugin => {
-      const [name, configurations] = plugin as [string, Record<string, any>];
-
-      if (name === 'mx-jpush-expo') {
-        return [
-          name,
-          {
-            ...configurations,
-            apsForProduction: isProduction,
-            appKey: process.env.JPUSH_APP_KEY ?? '',
-            channel: process.env.JPUSH_CHANNEL ?? configurations?.channel ?? '',
-            packageName:
-              process.env.JPUSH_PKGNAME ??
-              configurations?.packageName ??
-              config.android?.package ??
-              '',
-            vendorChannels: {
-              xiaomi: {
-                appId: process.env.JPUSH_XIAOMI_APP_ID,
-                appKey: process.env.JPUSH_XIAOMI_APP_KEY,
-              },
-              oppo: {
-                appKey: process.env.JPUSH_OPPO_APP_KEY,
-                appId: process.env.JPUSH_OPPO_APP_ID,
-                appSecret: process.env.JPUSH_OPPO_APP_SECRET,
-              },
-              vivo: {
-                appKey: process.env.JPUSH_VIVO_APP_KEY,
-                appId: process.env.JPUSH_VIVO_APP_ID,
-              },
-              meizu: {
-                appKey: process.env.JPUSH_MEIZU_APP_KEY,
-                appId: process.env.JPUSH_MEIZU_APP_ID,
-              },
-              honor: {
-                appId: process.env.JPUSH_HONOR_APP_ID,
-              },
-              nio: {
-                appId: process.env.JPUSH_NIO_APP_ID,
-              },
-              huawei: {
-                enabled: true,
-              },
-              fcm: {
-                enabled: true,
-              },
+    plugins: [
+      ...(config.plugins || []),
+      [
+        'mx-jpush-expo',
+        {
+          appKey: process.env.JPUSH_APP_KEY ?? '',
+          channel: process.env.JPUSH_CHANNEL ?? 'developer-default',
+          packageName:
+            process.env.JPUSH_PKGNAME ?? config.android?.package ?? '',
+          apsForProduction: isProduction,
+          vendorChannels: {
+            huawei: { enabled: true },
+            fcm: { enabled: true },
+            xiaomi: {
+              appId: process.env.JPUSH_XIAOMI_APP_ID,
+              appKey: process.env.JPUSH_XIAOMI_APP_KEY,
+            },
+            oppo: {
+              appId: process.env.JPUSH_OPPO_APP_ID,
+              appKey: process.env.JPUSH_OPPO_APP_KEY,
+              appSecret: process.env.JPUSH_OPPO_APP_SECRET,
+            },
+            vivo: {
+              appId: process.env.JPUSH_VIVO_APP_ID,
+              appKey: process.env.JPUSH_VIVO_APP_KEY,
+            },
+            meizu: {
+              appId: process.env.JPUSH_MEIZU_APP_ID,
+              appKey: process.env.JPUSH_MEIZU_APP_KEY,
+            },
+            honor: {
+              appId: process.env.JPUSH_HONOR_APP_ID,
+            },
+            nio: {
+              appId: process.env.JPUSH_NIO_APP_ID,
             },
           },
-        ];
-      }
-
-      return plugin;
-    }),
+        },
+      ],
+    ],
   };
 };
 ```
 
-#### Android 端环境变量
-Android `manifestPlaceholders` 现在按下面的优先级取值：
+### 配置要点
+
+- `appKey`、`channel`、`packageName` 仍然是插件必填项
+- iOS 初始化参数会写入 `Info.plist`，不再直接拼进 `AppDelegate.swift`
+- Android `manifestPlaceholders` 优先读取环境变量或 `gradle.properties`
+- `vendorChannels` 决定要注入哪些厂商 SDK 与占位符，厂商密钥本身建议交给环境变量
+
+## 环境变量与厂商通道
+
+Android 端的 `manifestPlaceholders` 读取优先级如下：
 
 1. `System.getenv("...")`
 2. `project.findProperty("...")`
-3. 插件收到的默认值（仅 `JPUSH_PKGNAME`）
-4. 空字符串（其余字段）
+3. 插件收到的默认值，仅 `JPUSH_PKGNAME`
+4. 空字符串，其余字段
 
-可用环境变量名：
+### 可用环境变量
 
-- `JPUSH_APP_KEY`
-- `JPUSH_CHANNEL`
-- `JPUSH_PKGNAME`
-- `JPUSH_XIAOMI_APP_ID`
-- `JPUSH_XIAOMI_APP_KEY`
-- `JPUSH_OPPO_APP_ID`
-- `JPUSH_OPPO_APP_KEY`
-- `JPUSH_OPPO_APP_SECRET`
-- `JPUSH_VIVO_APP_ID`
-- `JPUSH_VIVO_APP_KEY`
-- `JPUSH_MEIZU_APP_ID`
-- `JPUSH_MEIZU_APP_KEY`
-- `JPUSH_HONOR_APP_ID`
-- `JPUSH_NIO_APP_ID`
+| 变量名 | 说明 |
+| --- | --- |
+| `JPUSH_APP_KEY` | JPush AppKey |
+| `JPUSH_CHANNEL` | JPush Channel |
+| `JPUSH_PKGNAME` | Android 包名 |
+| `JPUSH_XIAOMI_APP_ID` / `JPUSH_XIAOMI_APP_KEY` | 小米通道 |
+| `JPUSH_OPPO_APP_ID` / `JPUSH_OPPO_APP_KEY` / `JPUSH_OPPO_APP_SECRET` | OPPO 通道 |
+| `JPUSH_VIVO_APP_ID` / `JPUSH_VIVO_APP_KEY` | VIVO 通道 |
+| `JPUSH_MEIZU_APP_ID` / `JPUSH_MEIZU_APP_KEY` | 魅族通道 |
+| `JPUSH_HONOR_APP_ID` | 荣耀通道 |
+| `JPUSH_NIO_APP_ID` | 蔚来通道 |
 
 示例 `.env`：
 
@@ -139,51 +191,53 @@ JPUSH_XIAOMI_APP_ID=your-xiaomi-app-id
 JPUSH_XIAOMI_APP_KEY=your-xiaomi-app-key
 ```
 
-也可以把这些值写到 `android/gradle.properties`，构建时会通过 `project.findProperty(...)` 读取。
+### 厂商通道额外要求
 
-#### 配置说明
-- `appKey`、`channel`、`packageName` 仍然是插件必填项，因为 iOS 注入代码和参数校验发生在 Expo 配置阶段。
-- iOS 现在改为从 `Info.plist` 读取 `JPUSH_APPKEY`、`JPUSH_CHANNEL` 和 `JPUSH_APS_FOR_PRODUCTION`，不再把这些值直接拼进 `AppDelegate.swift`。
-- 这能避免源码层的明文注入，但不能把它们变成客户端不可见的“秘密”，因为 JPush 初始化参数最终仍会出现在打包产物里。
-- Android 侧生成的 `manifestPlaceholders` 不再把这些值写死到 `build.gradle` 中。
-- `JPUSH_PKGNAME` 现在按 `System.getenv("JPUSH_PKGNAME") -> project.findProperty("JPUSH_PKGNAME") -> 插件收到的 packageName` 回退，不再依赖 `applicationId` 的声明顺序。
-- `vendorChannels` 的作用是决定要注入哪些厂商 SDK 和哪些占位符；真正的厂商密钥建议通过环境变量或 `gradle.properties` 提供。
-- 厂商通道配置是可选的，只需配置你实际使用的厂商。
-- 厂商通道插件版本：**5.9.0**。
+| 厂商 | 额外文件 | 签名要求 | 说明 |
+| --- | --- | --- | --- |
+| 华为 | `agconnect-services.json` | 需要 | 需配置 SHA256 指纹 |
+| FCM | `google-services.json` | 不需要 | 需在 Firebase 控制台申请 |
+| 荣耀 | 无 | 需要 | 需配置 SHA256 指纹 |
+| 蔚来 | 无 | 需要 | 需配置应用签名 |
+| 小米 | 无 | 不需要 | 仅需 AppId / AppKey |
+| OPPO | 无 | 不需要 | 仅需 AppId / AppKey / AppSecret |
+| VIVO | 无 | 不需要 | 仅需 AppId / AppKey |
+| 魅族 | 无 | 不需要 | 仅需 AppId / AppKey |
 
-#### 厂商通道额外配置
+官方参数说明见：[极光推送 Android 厂商通道参数获取](https://docs.jiguang.cn/jpush/client/Android/android_3rd_param)
 
-| 厂商 | 配置文件 | 应用签名 | 说明 |
-|------|---------|---------|------|
-| **华为** | `agconnect-services.json` | ✅ **必需** | 需在华为开发者联盟申请，配置 SHA256 指纹 |
-| **FCM** | `google-services.json` | ❌ | 需在 Firebase 控制台申请 |
-| **荣耀** | - | ✅ **必需** | 需在荣耀开发者平台配置 SHA256 指纹 |
-| **蔚来** | - | ✅ **必需** | 需在蔚来开发者平台配置应用签名 |
-| **小米** | - | ❌ | 仅需 AppId 和 AppKey |
-| **OPPO** | - | ❌ | 仅需 AppKey、AppId 和 AppSecret |
-| **VIVO** | - | ❌ | 仅需 AppKey 和 AppId |
-| **魅族** | - | ❌ | 仅需 AppKey 和 AppId |
+## 插件会修改哪些原生文件
 
-各厂商通道的详细配置步骤请参考极光官方文档：
+| 平台 | 文件 | 作用 |
+| --- | --- | --- |
+| iOS | `ios/<app>/Info.plist` | 写入 `JPUSH_*` 配置并合并 `UIBackgroundModes` |
+| iOS | `ios/<app>/AppDelegate.swift` | 注入 JPush 初始化、APNs 回调和代理扩展 |
+| iOS | `ios/<app>/<target>-Bridging-Header.h` | 复用或创建桥接头文件，保证 import 幂等 |
+| Android | `android/app/src/main/AndroidManifest.xml` | 写入 `JPUSH_APPKEY` / `JPUSH_CHANNEL` meta-data |
+| Android | `android/app/build.gradle` | 注入依赖、`manifestPlaceholders`、`abiFilters`、厂商插件 |
+| Android | `android/build.gradle` | 注入厂商 Maven 仓库与 classpath |
+| Android | `android/settings.gradle` | 注册 `jpush-react-native` / `jcore-react-native` 模块 |
+| Android | `android/gradle.properties` | 写入华为 AGC 兼容性开关 |
 
-📖 **[极光推送 - Android 厂商通道参数获取](https://docs.jiguang.cn/jpush/client/Android/android_3rd_param)**
+## 如何验证生成结果
 
-**配置文件位置**：
-- 将 `agconnect-services.json`（华为）或 `google-services.json`（FCM）放到 `android/app/` 目录
+重新执行 `expo prebuild` 后，建议检查：
 
-## 3.`prebuild`
-```bash
-npx expo prebuild -p android
-```
+### iOS
 
-如果同时需要刷新 iOS 工程，可以使用：
+- `Info.plist` 中存在：
+  - `JPUSH_APPKEY`
+  - `JPUSH_CHANNEL`
+  - `JPUSH_APS_FOR_PRODUCTION`
+- `UIBackgroundModes` 会保留宿主已有值，并补齐：
+  - `fetch`
+  - `remote-notification`
+- `AppDelegate.swift` 中存在 `JPUSHService.setup`
+- 如果项目使用 Swift，插件会优先复用已有 `SWIFT_OBJC_BRIDGING_HEADER`；未配置时会自动创建 `<target>-Bridging-Header.h`
 
-```bash
-npx expo prebuild
-```
+### Android
 
-## 4.检验
-重新生成后，检查 `android/app/build.gradle` 中的 `manifestPlaceholders`，应当是下面这种形式，而不是明文：
+`android/app/build.gradle` 中的 `manifestPlaceholders` 应保持“运行时读取”，而不是写死明文：
 
 ```gradle
 manifestPlaceholders = [
@@ -193,201 +247,85 @@ manifestPlaceholders = [
 ]
 ```
 
-同时建议检查 iOS 生成结果：
+## 常见问题
 
-- `ios/<app>/Info.plist` 中的 `UIBackgroundModes` 会保留宿主已有值，并自动补齐 `fetch` 和 `remote-notification`
-- 如果项目使用 Swift，插件会优先复用已有 `SWIFT_OBJC_BRIDGING_HEADER`；如果未配置，则自动创建 `<target>-Bridging-Header.h`
-- 重复执行 `expo prebuild` 不会重复追加 JPush 所需的 Bridging Header import
+### 是否支持 Expo Go？
 
-如果你是在业务项目里临时直接改 `node_modules/mx-jpush-expo`，重装依赖后修改会丢失，正式建议使用 `pnpm patch mx-jpush-expo` 固化。
+不支持。JPush 需要原生工程和原生依赖，必须通过 `expo prebuild` 进入 Dev Client 或原生构建流程。
 
-## 更新日志
+### 为什么 iOS 仍然要求在插件配置里填写 `appKey` / `channel`？
 
-### v1.2.2 (2026-03-08)
+因为参数校验和 `Info.plist` 注入都发生在 Expo 配置阶段。它们不会再被直接拼进 `AppDelegate.swift`，但仍然需要在配置阶段提供。
 
-- 修复 `JPUSH_PKGNAME` 依赖 `applicationId` 声明顺序的问题
-- `JPUSH_PKGNAME` 改为按 `环境变量 -> gradle.properties -> 插件 packageName` 回退
+### Android 遇到 Gradle 插件版本错误怎么办？
 
-### v1.2.1 (2026-03-08)
+如果你遇到类似 `com.android.tools.build:gradle is no set in the build.gradle file` 的错误，需要检查业务项目自己的 `android/build.gradle` 与 Expo 版本是否匹配。这不是本插件主动引入的行为变更。
 
-- Android `manifestPlaceholders` 改为在 Gradle 构建时读取环境变量或 `gradle.properties`
-- 不再把 `JPUSH_APPKEY`、`JPUSH_CHANNEL` 和厂商密钥明文写入 `android/app/build.gradle`
-- iOS 改为从 `Info.plist` 读取 JPush 初始化参数，不再把这些值直接注入 `AppDelegate.swift`
-- README 更新为 `app.config.ts + 环境变量` 的推荐用法
+### 直接改 `node_modules/mx-jpush-expo` 可以吗？
 
-### v1.1.0 (2025-12-17)
+不建议。重装依赖后会丢失，正式方式建议使用 `pnpm patch mx-jpush-expo` 或维护自己的 fork。
 
-**🎉 完整支持 Android 厂商通道**
-
-- ✨ 新增完整的 Android 厂商通道支持（华为、FCM、小米、OPPO、VIVO、魅族、荣耀、蔚来）
-- ✨ 自动配置厂商通道 SDK 依赖（JPush 5.9.0）
-- ✨ 自动配置 `manifestPlaceholders`（包括 `JPUSH_PKGNAME`）
-- ✨ 自动配置 NDK `abiFilters`
-- ✨ 自动配置华为和 FCM 的 `apply plugin` 语句
-- ✨ 自动配置 project/build.gradle（Maven 仓库和 classpath）
-- ✨ 新增 `packageName` 必填配置项
-- 📝 完善厂商通道配置文档，添加极光官方文档链接
-- 📝 添加应用签名配置说明（华为、荣耀、蔚来必需）
-- 🔧 优化代码结构，移除手动下载 aar 的要求
-
-### v1.0.2 (2024-09-27)
-> 📖 **参考文章**：[Expo SDK 53+ 集成极光推送 iOS Swift](https://juejin.cn/post/7554288083597885467)
-
-- ✨ 支持 Expo SDK 53+ 和 React Native 0.79.5+
-- ✨ 添加 iOS Swift/OC 混编支持（Bridging Header 配置）
-- ✨ 更新依赖版本：jpush-react-native@3.1.9, jcore-react-native@2.3.0
-- ✨ 添加推送权限说明配置（NSUserTrackingUsageDescription, NSMicrophoneUsageDescription）
-- 🐛 修复 iOS 新架构下的兼容性问题
-- 📝 更新文档，添加最新集成指南
-
-### v1.0.1
-> 📖 **参考文章**：[JPush 集成 Expo](https://juejin.cn/post/7423235127716659239)
-
-- 初始版本发布
-- 支持基础的 iOS 和 Android 集成
-
-## 注意事项
-
-### iOS 配置
-1. 确保在 Xcode 中开启 Push Notifications 能力
-2. 在极光推送控制台上传正确的推送证书（Development/Production）
-3. 验证 Bundle ID 与极光控制台完全匹配
-4. 如果使用 Swift，插件会自动复用或创建 Bridging Header，并写入 JPush 所需 import
-5. 插件会合并 `UIBackgroundModes`，不会覆盖宿主已有后台模式
-
-### Android 配置
-1. 确保在 AndroidManifest.xml 中已声明必要的权限
-2. 检查 Gradle 配置是否正确
-3. **签名配置（重要）**：华为、荣耀等厂商通道需要应用签名才能正常工作
-   - 将签名文件（如 `release.keystore`）放到 `android/app/` 目录
-   - 在 `android/app/build.gradle` 中配置签名：
-   ```gradle
-   android {
-       ...
-       signingConfigs {
-           release {
-               storeFile file("release.keystore")
-               storePassword "your_store_password"
-               keyAlias "your_key_alias"
-               keyPassword "your_key_password"
-           }
-       }
-       buildTypes {
-           release {
-               signingConfig signingConfigs.release
-               ...
-           }
-       }
-   }
-   ```
-   - **安全提示**：不要将密码直接写在代码中，建议使用环境变量或 `gradle.properties`：
-   ```gradle
-   // 在 gradle.properties 中配置（不要提交到 Git）
-   RELEASE_STORE_PASSWORD=your_store_password
-   RELEASE_KEY_PASSWORD=your_key_password
-   RELEASE_KEY_ALIAS=your_key_alias
-   
-   // 在 build.gradle 中读取
-   signingConfigs {
-       release {
-           storeFile file("release.keystore")
-           storePassword project.hasProperty('RELEASE_STORE_PASSWORD') ? RELEASE_STORE_PASSWORD : ''
-           keyAlias project.hasProperty('RELEASE_KEY_ALIAS') ? RELEASE_KEY_ALIAS : ''
-           keyPassword project.hasProperty('RELEASE_KEY_PASSWORD') ? RELEASE_KEY_PASSWORD : ''
-       }
-   }
-   ```
-
-### 常见问题
-
-#### iOS 相关
-- **推送证书问题**：检查证书是否过期，环境是否匹配（开发/生产）
-- **注册 ID 获取失败**：检查网络连接、AppKey 配置、推送权限
-- **冷启动通知丢失**：确保按正确顺序初始化（先设置监听器，再初始化 JPush）
-
-#### Android 相关
-- **Gradle 版本错误**：如果遇到 `com.android.tools.build:gradle is no set in the build.gradle file` 错误，需要在项目根目录的 `android/build.gradle` 中给 Gradle 插件添加版本号：
-  ```gradle
-  buildscript {
-      dependencies {
-          // 修改前
-          classpath('com.android.tools.build:gradle')
-          
-          // 修改后（添加版本号）
-          classpath('com.android.tools.build:gradle:8.6.3')
-      }
-  }
-  ```
-  版本号应与你的项目 Gradle 版本匹配，常见版本：
-  - Expo SDK 51+: `8.6.3` 或更高
-  - Expo SDK 50: `8.3.0`
-
-- **厂商通道推送失败**：
-  - 华为/荣耀/蔚来：检查是否配置了正确的 SHA256 签名指纹
-  - 所有厂商：确认 AppId/AppKey 配置正确
-  - 检查是否下载了必需的配置文件（华为的 `agconnect-services.json`、FCM 的 `google-services.json`）
-
-更多问题排查请参考：[Expo SDK 53+ 集成极光推送 iOS Swift - 常见问题与故障排查](https://juejin.cn/post/7554288083597885467)
-
-## 项目结构
-
-```
-mx-jpush-expo/
-├── app.plugin.js              # 主入口文件
-├── plugin/                    # 插件源码和构建
-│   ├── src/                  # TypeScript 源码
-│   │   ├── index.ts          # 插件主入口
-│   │   ├── types.ts          # 类型定义
-│   │   ├── utils/            # 工具模块
-│   │   │   └── config.ts     # 全局配置管理
-│   │   ├── ios/              # iOS 平台配置
-│   │   │   ├── index.ts      # iOS 配置集成
-│   │   │   ├── infoPlist.ts  # Info.plist 配置
-│   │   │   ├── appDelegate.ts # AppDelegate 实现
-│   │   │   ├── bridgingHeader.ts # Swift/OC 桥接头文件
-│   │   └── android/          # Android 平台配置
-│   │       ├── index.ts      # Android 配置集成
-│   │       ├── androidManifest.ts # AndroidManifest 配置
-│   │       ├── appBuildGradle.ts # app/build.gradle 配置
-│   │       ├── projectBuildGradle.ts # project/build.gradle 配置
-│   │       ├── settingsGradle.ts # settings.gradle 配置
-│   │       └── gradleProperties.ts # gradle.properties 配置
-│   ├── build/                # 编译后的 JS 文件（发布到 npm）
-│   ├── __tests__/            # 单元测试
-│   ├── tsconfig.json         # TypeScript 配置
-│   └── jest.config.js        # Jest 测试配置
-├── package.json
-├── README.md
-└── MIGRATION.md              # TypeScript 迁移指南
-```
-
-详细的模块说明请查看 [plugin/README.md](./plugin/README.md)
-
-## 开发
-
-### 构建插件
+## 开发与测试
 
 ```bash
 npm run build
+npm run test -- --runInBand
+npm run lint
 ```
 
-### 运行测试
+### 测试覆盖重点
 
-```bash
-npm run test
+- iOS `Info.plist` 合并与 Bridging Header 创建 / 幂等
+- iOS `AppDelegate.swift` 注入与幂等
+- Android `Manifest`、Gradle、Settings 和 `gradle.properties` 原生输出
+- fixture-based 回归测试，确保 `compileModsAsync` 输出稳定
+
+## 项目结构
+
+```text
+mx-jpush-expo/
+├── app.plugin.js
+├── plugin/
+│   ├── src/
+│   │   ├── index.ts
+│   │   ├── types.ts
+│   │   ├── ios/
+│   │   │   ├── infoPlist.ts
+│   │   │   ├── appDelegate.ts
+│   │   │   └── bridgingHeader.ts
+│   │   ├── android/
+│   │   │   ├── androidManifest.ts
+│   │   │   ├── appBuildGradle.ts
+│   │   │   ├── projectBuildGradle.ts
+│   │   │   ├── settingsGradle.ts
+│   │   │   └── gradleProperties.ts
+│   │   └── utils/
+│   ├── __tests__/
+│   │   ├── fixtures/
+│   │   ├── iosFixture.ts
+│   │   ├── androidFixture.ts
+│   │   └── *.test.ts
+│   └── build/
+├── .github/workflows/ci.yml
+└── README.md
 ```
 
-### 清理构建文件
+插件内部说明见 [plugin/README.md](./plugin/README.md)。
 
-```bash
-npm run clean
-```
+## 最近更新
 
-## 致谢
+- iOS `UIBackgroundModes` 改为合并写入，不再覆盖宿主已有后台模式
+- Swift `Bridging Header` 支持优先复用、缺失自动创建，并保持幂等
+- 补齐 iOS / Android fixture-based 原生回归测试
+- 加入 ESLint 与 CI 质量闭环
+- 对齐 Expo SDK 53 的版本声明与仓库开发基线
 
-感谢以下掘金文章作者的技术分享：
-- [@折七](https://juejin.cn/user/7423235127716659239) - JPush 集成 Expo 基础方案
+## 致谢与许可
 
-## License
+感谢以下资料与实现思路的启发：
 
-MIT
+- [JPush 集成 Expo](https://juejin.cn/post/7423235127716659239)
+- [Expo SDK 53+ 集成极光推送 iOS Swift](https://juejin.cn/post/7554288083597885467)
+- [RunoMeow/jpush-expo-config-plugin](https://github.com/RunoMeow/jpush-expo-config-plugin)
+
+本项目使用 [MIT License](./LICENSE)。

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -6,33 +6,33 @@
 
 ```text
 plugin/
-├── src/
-│   ├── index.ts
-│   ├── types.ts
+├── src/                         # TypeScript 源码
+│   ├── index.ts                # 主入口文件
+│   ├── types.ts                # 类型定义和参数验证
 │   ├── utils/
-│   │   ├── config.ts
-│   │   ├── codeValidator.ts
-│   │   └── generateCode.ts
-│   ├── ios/
-│   │   ├── index.ts
-│   │   ├── infoPlist.ts
-│   │   ├── appDelegate.ts
-│   │   └── bridgingHeader.ts
-│   ├── android/
-│   │   ├── index.ts
-│   │   ├── androidManifest.ts
-│   │   ├── appBuildGradle.ts
-│   │   ├── projectBuildGradle.ts
-│   │   ├── settingsGradle.ts
-│   │   └── gradleProperties.ts
-├── __tests__/
+│   │   ├── config.ts           # 全局配置管理
+│   │   ├── codeValidator.ts    # 注入结果校验
+│   │   └── generateCode.ts     # 原生代码注入工具
+│   ├── ios/                    # iOS 平台配置
+│   │   ├── index.ts            # iOS 配置集成入口
+│   │   ├── infoPlist.ts        # Info.plist 配置
+│   │   ├── appDelegate.ts      # AppDelegate 实现配置
+│   │   └── bridgingHeader.ts   # Swift/OC 桥接头文件配置
+│   └── android/                # Android 平台配置
+│       ├── index.ts            # Android 配置集成入口
+│       ├── androidManifest.ts  # AndroidManifest.xml 配置
+│       ├── appBuildGradle.ts   # app/build.gradle 配置
+│       ├── projectBuildGradle.ts # project/build.gradle 配置
+│       ├── settingsGradle.ts   # settings.gradle 配置
+│       └── gradleProperties.ts # gradle.properties 配置
+├── __tests__/                  # 测试目录
 │   ├── fixtures/
-│   │   └── ios-project/
-│   ├── iosFixture.ts
-│   └── *.test.ts
-├── build/
-├── tsconfig.json
-└── jest.config.js
+│   │   └── ios-project/        # iOS 原生 fixture
+│   ├── iosFixture.ts           # iOS fixture helper
+│   └── *.test.ts               # Jest 用例
+├── build/                      # 编译后的 JavaScript 文件（npm 发布）
+├── tsconfig.json               # TypeScript 配置
+└── jest.config.js              # Jest 测试配置
 ```
 
 ## 模块职责

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,6 +2,12 @@
 
 `plugin/` 目录承载了 `mx-jpush-expo` 的 TypeScript 实现、原生 fixture 测试和编译产物，是贡献者理解插件行为的第一入口。
 
+相关文档：
+
+- 接入与使用说明：[`README.md`](../README.md)
+- 开发流程与发布说明：[`DEVELOPMENT.md`](../DEVELOPMENT.md)
+- 历史版本更新：[`CHANGELOG.md`](../CHANGELOG.md)
+
 ## 目录概览
 
 ```text

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,6 +9,10 @@ plugin/
 ├── src/
 │   ├── index.ts
 │   ├── types.ts
+│   ├── utils/
+│   │   ├── config.ts
+│   │   ├── codeValidator.ts
+│   │   └── generateCode.ts
 │   ├── ios/
 │   │   ├── index.ts
 │   │   ├── infoPlist.ts
@@ -21,15 +25,10 @@ plugin/
 │   │   ├── projectBuildGradle.ts
 │   │   ├── settingsGradle.ts
 │   │   └── gradleProperties.ts
-│   └── utils/
-│       ├── codeValidator.ts
-│       └── generateCode.ts
 ├── __tests__/
 │   ├── fixtures/
-│   │   ├── ios-project/
-│   │   └── android-project/
+│   │   └── ios-project/
 │   ├── iosFixture.ts
-│   ├── androidFixture.ts
 │   └── *.test.ts
 ├── build/
 ├── tsconfig.json
@@ -40,21 +39,22 @@ plugin/
 
 | 模块 | 职责 |
 | --- | --- |
-| `src/index.ts` | 插件入口，负责参数校验、配置归一化和平台分发 |
-| `src/types.ts` | 类型定义、参数校验、内部 resolved config |
+| `src/index.ts` | 插件入口，负责参数校验、配置初始化和平台分发 |
+| `src/types.ts` | 类型定义与参数校验 |
 | `src/ios/*` | iOS 原生输出注入 |
 | `src/android/*` | Android 原生输出注入 |
+| `src/utils/config.ts` | 当前主线的共享配置流转 |
 | `src/utils/*` | 代码注入与校验工具 |
 | `__tests__/fixtures/*` | 最小原生模板，用于回归测试 |
-| `iosFixture.ts` / `androidFixture.ts` | fixture 生命周期、复制、编译与读取 helper |
+| `iosFixture.ts` | iOS fixture 生命周期、复制、编译与读取 helper |
 
 ## 当前实现约束
 
 ### 配置流转
 
 - 对外入口仍然使用 `JPushPluginProps`
-- 插件入口会先做参数校验，再生成内部 resolved config
-- 平台模块通过显式传参拿到配置，不再依赖模块级全局可变状态
+- 插件入口会先做参数校验，再通过 `setConfig/get*` 在模块间共享配置
+- 当前主线仍依赖模块级配置流转；如果后续继续重构，可再收敛到显式传参
 
 ### iOS
 
@@ -78,15 +78,14 @@ plugin/
 | --- | --- |
 | `withJPush.test.ts` | 参数校验与插件入口基础行为 |
 | `nativeIosSmoke.test.ts` | iOS 主流程 smoke |
-| `nativeIosMods.test.ts` | `Info.plist`、Bridging Header、配置隔离 |
-| `nativeIosAppDelegate.test.ts` | `AppDelegate.swift` 注入与幂等 |
-| `nativeAndroidMods.test.ts` | Android Manifest / Gradle / 配置隔离 |
+| `nativeIosMods.test.ts` | `Info.plist`、Bridging Header |
 
 ### 为什么使用 fixture
 
 - 直接验证 `compileModsAsync` 的真实输出
 - 能覆盖正则锚点、幂等性和模板兼容性
 - 比只断言 helper 返回值更接近业务项目里的 `expo prebuild`
+- Android 与 `AppDelegate` 的细粒度 fixture 覆盖可以继续在后续 PR 中补齐
 
 ## 本地开发
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,112 +1,106 @@
-# Plugin 目录结构
+# Plugin 开发说明
 
-本目录包含了 JPush Expo Config Plugin 的 TypeScript 实现。
+`plugin/` 目录承载了 `mx-jpush-expo` 的 TypeScript 实现、原生 fixture 测试和编译产物，是贡献者理解插件行为的第一入口。
 
-## 目录结构
+## 目录概览
 
-```
+```text
 plugin/
-├── src/                       # TypeScript 源码
-│   ├── index.ts              # 主入口文件
-│   ├── types.ts              # 类型定义和参数验证
-│   ├── utils/
-│   │   └── config.ts         # 全局配置管理
-│   ├── ios/                  # iOS 平台配置
-│   │   ├── index.ts          # iOS 配置集成入口
-│   │   ├── infoPlist.ts      # Info.plist 配置
-│   │   ├── appDelegate.ts    # AppDelegate 实现配置
-│   │   ├── bridgingHeader.ts # Swift/OC 桥接头文件配置
-│   └── android/              # Android 平台配置
-│       ├── index.ts          # Android 配置集成入口
-│       ├── androidManifest.ts # AndroidManifest.xml 配置
-│       ├── appBuildGradle.ts # app/build.gradle 配置
-│       ├── projectBuildGradle.ts # project/build.gradle 配置
-│       ├── settingsGradle.ts # settings.gradle 配置
-│       └── gradleProperties.ts # gradle.properties 配置
-├── build/                    # 编译后的 JavaScript 文件（npm 发布）
-├── __tests__/                # 单元测试
-│   └── withJPush.test.ts     # 参数校验测试
-├── tsconfig.json             # TypeScript 配置
-└── jest.config.js            # Jest 测试配置
+├── src/
+│   ├── index.ts
+│   ├── types.ts
+│   ├── ios/
+│   │   ├── index.ts
+│   │   ├── infoPlist.ts
+│   │   ├── appDelegate.ts
+│   │   └── bridgingHeader.ts
+│   ├── android/
+│   │   ├── index.ts
+│   │   ├── androidManifest.ts
+│   │   ├── appBuildGradle.ts
+│   │   ├── projectBuildGradle.ts
+│   │   ├── settingsGradle.ts
+│   │   └── gradleProperties.ts
+│   └── utils/
+│       ├── codeValidator.ts
+│       └── generateCode.ts
+├── __tests__/
+│   ├── fixtures/
+│   │   ├── ios-project/
+│   │   └── android-project/
+│   ├── iosFixture.ts
+│   ├── androidFixture.ts
+│   └── *.test.ts
+├── build/
+├── tsconfig.json
+└── jest.config.js
 ```
 
-## 模块说明
+## 模块职责
 
-### 主入口 (src/index.ts)
-- 插件的主入口文件
-- 使用 `createRunOncePlugin` 确保插件只运行一次
-- 负责参数验证和配置初始化
-- 调用 iOS 和 Android 配置模块
+| 模块 | 职责 |
+| --- | --- |
+| `src/index.ts` | 插件入口，负责参数校验、配置归一化和平台分发 |
+| `src/types.ts` | 类型定义、参数校验、内部 resolved config |
+| `src/ios/*` | iOS 原生输出注入 |
+| `src/android/*` | Android 原生输出注入 |
+| `src/utils/*` | 代码注入与校验工具 |
+| `__tests__/fixtures/*` | 最小原生模板，用于回归测试 |
+| `iosFixture.ts` / `androidFixture.ts` | fixture 生命周期、复制、编译与读取 helper |
 
-### 类型定义 (src/types.ts)
-- `JPushPluginProps`: 插件配置参数接口
-- `validateProps`: 参数验证函数
+## 当前实现约束
 
-### 工具模块 (src/utils/)
-- **config.ts**: 管理全局配置（AppKey、Channel、apsForProduction）
+### 配置流转
 
-### iOS 模块 (src/ios/)
-- **index.ts**: iOS 配置的集成入口
-- **infoPlist.ts**: 配置 Info.plist，写入 JPush 初始化参数并合并后台模式
-- **appDelegate.ts**: 注入 JPush 初始化和事件处理代码
-- **bridgingHeader.ts**: 复用或创建 Swift/OC 混编的桥接头文件，并保证 import 幂等
+- 对外入口仍然使用 `JPushPluginProps`
+- 插件入口会先做参数校验，再生成内部 resolved config
+- 平台模块通过显式传参拿到配置，不再依赖模块级全局可变状态
 
-### Android 模块 (src/android/)
-- **index.ts**: Android 配置的集成入口
-- **androidManifest.ts**: 配置 AndroidManifest.xml meta-data
-- **appBuildGradle.ts**: 配置 `app/build.gradle` 依赖和 `manifestPlaceholders`
-- **projectBuildGradle.ts**: 配置 project 级 Gradle 仓库和 classpath
-- **settingsGradle.ts**: 配置 `settings.gradle` 模块引用
-- **gradleProperties.ts**: 配置 Gradle 兼容性属性
+### iOS
 
-### 测试模块 (__tests__/)
-- **withJPush.test.ts**: 参数校验和插件入口的基础测试
+- `infoPlist.ts` 负责 `JPUSH_*` 键和 `UIBackgroundModes`
+- `appDelegate.ts` 负责 Swift 注入
+- `bridgingHeader.ts` 负责复用或创建桥接头文件，并设置 `SWIFT_OBJC_BRIDGING_HEADER`
 
-## 设计原则
+### Android
 
-1. **单一职责**: 每个文件只负责一个特定的配置任务
-2. **模块化**: 按平台和功能拆分，便于维护和扩展
-3. **类型安全**: 使用 TypeScript 提供编译时类型检查
-4. **可测试性**: 每个模块都可以独立测试
-5. **清晰的依赖**: 通过 utils/config.ts 管理共享状态
-6. **符合官方规范**: 遵循 Expo Config Plugin 最佳实践
+- `androidManifest.ts` 负责 `JPUSH_APPKEY` / `JPUSH_CHANNEL` meta-data
+- `appBuildGradle.ts` 负责依赖、`manifestPlaceholders`、`abiFilters` 与 `apply plugin`
+- `projectBuildGradle.ts` 负责 Maven 仓库与 classpath
+- `settingsGradle.ts` 负责 `jpush-react-native` / `jcore-react-native` 模块注入
+- `gradleProperties.ts` 负责华为 AGC 兼容性属性
 
-## 命名约定
+## 测试策略
 
-根据 [Expo 官方文档](https://docs.expo.dev/config-plugins/development-for-libraries/)：
+当前主线使用 fixture-based 回归测试，而不只做参数校验。
 
-- 全平台函数：`withFeatureName`
-- iOS 特定函数：`withIosFeatureName`
-- Android 特定函数：`withAndroidFeatureName`
+| 测试文件 | 覆盖内容 |
+| --- | --- |
+| `withJPush.test.ts` | 参数校验与插件入口基础行为 |
+| `nativeIosSmoke.test.ts` | iOS 主流程 smoke |
+| `nativeIosMods.test.ts` | `Info.plist`、Bridging Header、配置隔离 |
+| `nativeIosAppDelegate.test.ts` | `AppDelegate.swift` 注入与幂等 |
+| `nativeAndroidMods.test.ts` | Android Manifest / Gradle / 配置隔离 |
 
-示例：
-- `withIosInfoPlist` - iOS Info.plist 配置
-- `withIosAppDelegate` - iOS AppDelegate 配置
-- `withAndroidManifestConfig` - Android Manifest 配置
+### 为什么使用 fixture
 
-## 构建
+- 直接验证 `compileModsAsync` 的真实输出
+- 能覆盖正则锚点、幂等性和模板兼容性
+- 比只断言 helper 返回值更接近业务项目里的 `expo prebuild`
+
+## 本地开发
+
+在仓库根目录执行：
 
 ```bash
-# 从项目根目录运行
 npm run build
+npm run test -- --runInBand
+npm run lint
 ```
 
-这会将 TypeScript 源码编译到 `plugin/build/` 目录。
+## 贡献建议
 
-## 测试
-
-```bash
-# 从项目根目录运行
-npm test
-```
-
-当前主线包含基础的参数校验测试。
-
-## 开发
-
-修改源码后，需要重新构建：
-
-```bash
-npm run clean  # 清理旧的构建文件
-npm run build  # 重新构建
-```
+- 改动原生输出逻辑时，优先补 fixture 回归测试
+- 尽量保持每个模块只处理一个原生文件或一个原生职责
+- 如果新增平台配置，先决定它属于 `Info.plist`、Gradle、Manifest 还是 `AppDelegate` 哪一层，再落实现
+- 如果 README 需要新增接入说明，优先更新根目录 `README.md`；这里更适合写贡献者视角的信息


### PR DESCRIPTION
## Summary
- redesign the root README into a clearer OSS-style landing page with badges, quick start, and support matrix
- tighten the main usage guidance around prebuild, environment variables, and generated native outputs
- refresh plugin/README.md for contributor-facing architecture and test guidance

## Validation
- checked badge targets, package metadata, and workflow references
- reviewed markdown structure and links locally