### PR TITLE
chore(repo): ignore local coverage output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+coverage/


### PR DESCRIPTION
## Summary
- ignore generated coverage output in `.gitignore`
- prevent local Jest coverage artifacts under `plugin/coverage/` from showing up as untracked repo changes

## Testing
- verified `plugin/coverage/` is ignored by git after updating `.gitignore`