### PR TITLE
fix(android): harden gradle injection edge cases

### DIFF
--- a/plugin/__tests__/androidTransforms.test.ts
+++ b/plugin/__tests__/androidTransforms.test.ts
@@ -29,7 +29,7 @@ describe('Android transforms', () => {
     const repeated = applyAndroidAppBuildGradle(transformed, vendorChannels);
 
     expect(transformed).toContain('defaultConfig {');
-    expect(transformed).toContain('manifestPlaceholders = [');
+    expect(transformed).toContain('manifestPlaceholders += [');
     expect(transformed).toContain(`implementation 'cn.jiguang.sdk.plugin:huawei:5.9.0'`);
     expect(transformed).toContain(`implementation 'cn.jiguang.sdk.plugin:fcm:5.9.0'`);
     expect(transformed).toContain(`implementation 'cn.jiguang.sdk.plugin:xiaomi:5.9.0'`);
@@ -100,12 +100,13 @@ describe('Android transforms', () => {
     const upgraded = applyAndroidAppBuildGradle(withLegacyFileTree, undefined);
 
     expect(upgraded).not.toContain('@generated begin jpush-ndk-config');
-    expect(upgraded).not.toContain('@generated begin jpush-manifest-placeholders');
     expect(upgraded).not.toContain('@generated begin jpush-libs-filetree');
+    expect(upgraded).not.toContain(`JPUSH_APPKEY: 'legacy'`);
+    expect(upgraded).toContain('manifestPlaceholders += [');
     const matches = upgraded.match(
       /implementation fileTree\(include: \['\*.jar','\*.aar'\], dir: 'libs'\)/g
     );
-    expect(matches?.length || 0).toBeGreaterThanOrEqual(0);
+    expect(matches).toHaveLength(1);
   });
 
   it('should inject and remove project/build.gradle vendor sections', () => {

--- a/plugin/__tests__/nativeAndroidMods.test.ts
+++ b/plugin/__tests__/nativeAndroidMods.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { compileModsAsync } from 'expo/config-plugins';
 import withJPush from '../src';
 import {
@@ -8,6 +9,7 @@ import {
   SETTINGS_GRADLE_PATH,
   compileAndroidMods,
   createProjectRoot,
+  getFixturePath,
   readFixtureFile,
   registerAndroidFixtureLifecycleHooks,
 } from './androidFixture';
@@ -272,6 +274,71 @@ describe('native Android config mods', () => {
     );
     expect(appBuildGradle).toContain(
       'JPUSH_CHANNEL: System.getenv("JPUSH_CHANNEL") ?: (project.findProperty("JPUSH_CHANNEL") ?: "non-eas-channel")'
+    );
+  });
+
+  it('merges JPush manifestPlaceholders after existing host placeholders', async () => {
+    const projectRoot = createProjectRoot();
+    const buildGradlePath = getFixturePath(projectRoot, APP_BUILD_GRADLE_PATH);
+    const hostBuildGradle = fs.readFileSync(buildGradlePath, 'utf8').replace(
+      'versionName "1.0.0"',
+      'versionName "1.0.0"\n        manifestPlaceholders = [existingKey: "existing", JPUSH_CHANNEL: "host-channel"]'
+    );
+
+    fs.writeFileSync(buildGradlePath, hostBuildGradle);
+
+    await compileAndroidMods(projectRoot, {
+      appKey: 'merged-app-key',
+      channel: 'merged-channel',
+      packageName: 'com.example.merged',
+    });
+
+    const appBuildGradle = readFixtureFile(projectRoot, APP_BUILD_GRADLE_PATH);
+
+    expect(appBuildGradle).toContain(
+      'manifestPlaceholders = [existingKey: "existing", JPUSH_CHANNEL: "host-channel"]'
+    );
+    expect(appBuildGradle).toContain('manifestPlaceholders += [');
+    expect(appBuildGradle).toContain(
+      'JPUSH_CHANNEL: System.getenv("JPUSH_CHANNEL") ?: (project.findProperty("JPUSH_CHANNEL") ?: "merged-channel")'
+    );
+    expect(countOccurrences(appBuildGradle, 'manifestPlaceholders = [')).toBe(1);
+  });
+
+  it.each([
+    {
+      name: 'without versionName',
+      transform: (contents: string) =>
+        contents.replace(/\n\s*versionName\s+"1\.0\.0"/, ''),
+    },
+    {
+      name: 'with a non-literal versionName',
+      transform: (contents: string) =>
+        contents.replace(
+          'versionName "1.0.0"',
+          'def appVersionName = providers.gradleProperty("appVersionName").orElse("1.0.0").get()\n        versionName appVersionName'
+        ),
+    },
+  ])('prebuilds app/build.gradle %s', async ({ transform }) => {
+    const projectRoot = createProjectRoot();
+    const buildGradlePath = getFixturePath(projectRoot, APP_BUILD_GRADLE_PATH);
+    const hostBuildGradle = transform(fs.readFileSync(buildGradlePath, 'utf8'));
+
+    fs.writeFileSync(buildGradlePath, hostBuildGradle);
+
+    await expect(
+      compileAndroidMods(projectRoot, {
+        appKey: 'edge-app-key',
+        channel: 'edge-channel',
+        packageName: 'com.example.edge',
+      })
+    ).resolves.toBeUndefined();
+
+    const appBuildGradle = readFixtureFile(projectRoot, APP_BUILD_GRADLE_PATH);
+
+    expect(appBuildGradle).toContain('manifestPlaceholders += [');
+    expect(appBuildGradle).toContain(
+      'JPUSH_APPKEY: System.getenv("JPUSH_APP_KEY") ?: (project.findProperty("JPUSH_APP_KEY") ?: "edge-app-key")'
     );
   });
 

--- a/plugin/src/android/appBuildGradle.ts
+++ b/plugin/src/android/appBuildGradle.ts
@@ -35,6 +35,13 @@ type ResolvedAndroidBuildGradleConfig = {
   vendorChannels?: VendorChannelConfig;
 };
 
+type AndroidBuildGradleConfigInput = {
+  packageName?: string;
+  appKey?: string;
+  channel?: string;
+  vendorChannels?: VendorChannelConfig;
+};
+
 const gradleEnv = (key: string, fallback = '""'): string =>
   `System.getenv("${key}") ?: (project.findProperty("${key}") ?: ${fallback})`;
 
@@ -44,12 +51,12 @@ function removeLegacyGeneratedSections(contents: string, tags: string[]): string
   }, contents);
 }
 
-function getResolvedConfig(
-  appKey?: string,
-  channel?: string,
-  packageName?: string,
-  vendorChannels?: VendorChannelConfig
-): ResolvedAndroidBuildGradleConfig {
+function getResolvedConfig({
+  packageName,
+  appKey,
+  channel,
+  vendorChannels,
+}: AndroidBuildGradleConfigInput): ResolvedAndroidBuildGradleConfig {
   const fallbackConfig = getConfig();
 
   return {
@@ -154,6 +161,8 @@ function getManifestPlaceholders(
   const valueIndent = `${indent}    `;
 
   return [
+    // Append after any host map so unrelated placeholders stay intact while
+    // JPUSH_* defaults can still take precedence when the same key is reused.
     `${indent}manifestPlaceholders += [`,
     placeholders
       .map((placeholder, index) => {
@@ -279,7 +288,12 @@ export function applyAndroidAppBuildGradle(
   appKey?: string,
   channel?: string
 ): string {
-  const resolvedConfig = getResolvedConfig(appKey, channel, packageName, vendorChannels);
+  const resolvedConfig = getResolvedConfig({
+    packageName,
+    appKey,
+    channel,
+    vendorChannels,
+  });
 
   let nextContents = removeLegacyGeneratedSections(contents, LEGACY_DEFAULT_CONFIG_TAGS);
   nextContents = ensureNestedBlock(nextContents, /^\s*android\s*\{/, 'defaultConfig');

--- a/plugin/src/android/appBuildGradle.ts
+++ b/plugin/src/android/appBuildGradle.ts
@@ -6,38 +6,116 @@
 import { ExpoConfig } from 'expo/config';
 import { withAppBuildGradle } from 'expo/config-plugins';
 import { ResolvedJPushPluginProps, VendorChannelConfig } from '../types';
-import { mergeContents, removeGeneratedContents, syncGeneratedContentsAtLine, syncGeneratedContentsAtEnd } from '../utils/generateCode';
-import { Validator } from '../utils/codeValidator';
-import { ensureNestedBlock, ensureTopLevelBlock, findLineIndex } from '../utils/sourceCode';
-
-/**
- * 生成 NDK abiFilters 配置
- */
-const getNdkConfig = (): string => {
-  return `ndk {
-                //选择要添加的对应 cpu 类型的 .so 库。
-                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
-            }`;
-};
+import {
+  removeGeneratedContents,
+  replaceGeneratedContentsAtLine,
+  syncGeneratedContentsAtEnd,
+} from '../utils/generateCode';
+import { getConfig } from '../utils/config';
+import {
+  ensureNestedBlock,
+  ensureTopLevelBlock,
+  findBlockRange,
+  findLineIndex,
+  findNestedBlockRange,
+  getLineIndent,
+} from '../utils/sourceCode';
 
 const LEGACY_DEFAULT_CONFIG_TAGS = [
+  'jpush-default-config',
   'jpush-ndk-config',
   'jpush-manifest-placeholders',
 ];
 const LEGACY_DEPENDENCY_TAGS = ['jpush-libs-filetree'];
 
-/**
- * 生成 defaultConfig 中的 JPush 配置
- */
+type ResolvedAndroidBuildGradleConfig = {
+  appKey: string;
+  channel: string;
+  packageName: string;
+  vendorChannels?: VendorChannelConfig;
+};
+
 const gradleEnv = (key: string, fallback = '""'): string =>
   `System.getenv("${key}") ?: (project.findProperty("${key}") ?: ${fallback})`;
 
-const getManifestPlaceholders = (
+function removeLegacyGeneratedSections(contents: string, tags: string[]): string {
+  return tags.reduce((currentContents, tag) => {
+    return removeGeneratedContents(currentContents, tag) ?? currentContents;
+  }, contents);
+}
+
+function getResolvedConfig(
+  appKey?: string,
+  channel?: string,
+  packageName?: string,
+  vendorChannels?: VendorChannelConfig
+): ResolvedAndroidBuildGradleConfig {
+  const fallbackConfig = getConfig();
+
+  return {
+    appKey: appKey ?? fallbackConfig?.appKey ?? '',
+    channel: channel ?? fallbackConfig?.channel ?? '',
+    packageName: packageName ?? fallbackConfig?.packageName ?? '',
+    vendorChannels: vendorChannels ?? fallbackConfig?.vendorChannels,
+  };
+}
+
+function getBlockRangeOrThrow(src: string, pattern: RegExp, errorMessage: string) {
+  const range = findBlockRange(src, pattern);
+
+  if (!range) {
+    throw new Error(errorMessage);
+  }
+
+  return range;
+}
+
+function getDefaultConfigRange(src: string) {
+  return getBlockRangeOrThrow(
+    src,
+    /^\s*defaultConfig\s*\{/,
+    '[MX_JPush_Expo] 未找到 defaultConfig 配置块'
+  );
+}
+
+function getDependenciesLine(src: string): number {
+  const lineIndex = findLineIndex(src, /^\s*dependencies\s*\{/);
+
+  if (lineIndex < 0) {
+    throw new Error('[MX_JPush_Expo] 未找到 dependencies 配置块');
+  }
+
+  return lineIndex;
+}
+
+function getNdkRange(src: string) {
+  const range = findNestedBlockRange(
+    src,
+    /^\s*defaultConfig\s*\{/,
+    /^\s*ndk\s*\{/
+  );
+
+  if (!range) {
+    throw new Error('[MX_JPush_Expo] 未找到 defaultConfig.ndk 配置块');
+  }
+
+  return range;
+}
+
+function getChildIndent(src: string, pattern: RegExp, errorMessage: string): string {
+  const range = getBlockRangeOrThrow(src, pattern, errorMessage);
+  const lines = src.split('\n');
+
+  return `${getLineIndent(lines[range.startLine])}    `;
+}
+
+function getManifestPlaceholders(
   packageName: string,
   appKey: string,
   channel: string,
-  vendorChannels?: VendorChannelConfig
-): string => {
+  vendorChannels: VendorChannelConfig | undefined,
+  indent: string
+): string {
   const placeholders: string[] = [
     `JPUSH_PKGNAME: ${gradleEnv('JPUSH_PKGNAME', `"${packageName}"`)}`,
     `JPUSH_APPKEY: ${gradleEnv('JPUSH_APP_KEY', `"${appKey}"`)}`,
@@ -73,20 +151,36 @@ const getManifestPlaceholders = (
     placeholders.push(`NIO_APPID: ${gradleEnv('JPUSH_NIO_APP_ID')}`);
   }
 
-  return `manifestPlaceholders = [
-                ${placeholders.join(',\n                ')}
-            ]`;
-};
+  const valueIndent = `${indent}    `;
 
-/**
- * 生成 JPush SDK 依赖代码
- */
-const getJPushDependencies = (
-  vendorChannels?: VendorChannelConfig
-): string => {
+  return [
+    `${indent}manifestPlaceholders += [`,
+    placeholders
+      .map((placeholder, index) => {
+        const separator = index === placeholders.length - 1 ? '' : ',';
+        return `${valueIndent}${placeholder}${separator}`;
+      })
+      .join('\n'),
+    `${indent}]`,
+  ].join('\n');
+}
+
+function getNdkAbiFilters(indent: string): string {
+  return [
+    `${indent}// 选择要添加的对应 cpu 类型的 .so 库。`,
+    `${indent}abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'`,
+  ].join('\n');
+}
+
+function getJPushDependencies(
+  vendorChannels: VendorChannelConfig | undefined,
+  indent: string
+): string {
   const isHuaweiEnabled = vendorChannels?.huawei?.enabled === true;
   const isFcmEnabled = vendorChannels?.fcm?.enabled === true;
   const dependencies: string[] = [
+    `implementation fileTree(include: ['*.jar','*.aar'], dir: 'libs')`,
+    ``,
     `// JPush React Native 桥接（已包含 JPush 核心 SDK）`,
     `implementation project(':jpush-react-native')`,
     `implementation project(':jcore-react-native')`,
@@ -104,8 +198,9 @@ const getJPushDependencies = (
           vendorChannels.honor ||
           vendorChannels.nio
       );
+
     if (hasVendorChannels) {
-      dependencies.push(``, `// 厂商通道 SDK（JPush 5.9.0）`);
+      dependencies.push('', `// 厂商通道 SDK（JPush 5.9.0）`);
     }
 
     if (isHuaweiEnabled) {
@@ -126,24 +221,15 @@ const getJPushDependencies = (
     }
 
     if (vendorChannels.meizu) {
-      dependencies.push(
-        `// 魅族厂商`,
-        `implementation 'cn.jiguang.sdk.plugin:meizu:5.9.0'`
-      );
+      dependencies.push(`// 魅族厂商`, `implementation 'cn.jiguang.sdk.plugin:meizu:5.9.0'`);
     }
 
     if (vendorChannels.vivo) {
-      dependencies.push(
-        `// VIVO 厂商`,
-        `implementation 'cn.jiguang.sdk.plugin:vivo:5.9.0'`
-      );
+      dependencies.push(`// VIVO 厂商`, `implementation 'cn.jiguang.sdk.plugin:vivo:5.9.0'`);
     }
 
     if (vendorChannels.xiaomi) {
-      dependencies.push(
-        `// 小米厂商`,
-        `implementation 'cn.jiguang.sdk.plugin:xiaomi:5.9.0'`
-      );
+      dependencies.push(`// 小米厂商`, `implementation 'cn.jiguang.sdk.plugin:xiaomi:5.9.0'`);
     }
 
     if (vendorChannels.oppo) {
@@ -157,27 +243,20 @@ const getJPushDependencies = (
     }
 
     if (vendorChannels.honor) {
-      dependencies.push(
-        `// 荣耀厂商`,
-        `implementation 'cn.jiguang.sdk.plugin:honor:5.9.0'`
-      );
+      dependencies.push(`// 荣耀厂商`, `implementation 'cn.jiguang.sdk.plugin:honor:5.9.0'`);
     }
 
     if (vendorChannels.nio) {
-      dependencies.push(
-        `// 蔚来厂商`,
-        `implementation 'cn.jiguang.sdk.plugin:nio:5.9.0'`
-      );
+      dependencies.push(`// 蔚来厂商`, `implementation 'cn.jiguang.sdk.plugin:nio:5.9.0'`);
     }
   }
 
-  return dependencies.join('\n    ');
-};
+  return dependencies
+    .map((dependency) => (dependency ? `${indent}${dependency}` : dependency))
+    .join('\n');
+}
 
-/**
- * 生成 apply plugin 语句
- */
-const getApplyPlugins = (vendorChannels?: VendorChannelConfig): string => {
+function getApplyPlugins(vendorChannels?: VendorChannelConfig): string {
   const isHuaweiEnabled = vendorChannels?.huawei?.enabled === true;
   const isFcmEnabled = vendorChannels?.fcm?.enabled === true;
   const plugins: string[] = [];
@@ -190,19 +269,8 @@ const getApplyPlugins = (vendorChannels?: VendorChannelConfig): string => {
     plugins.push(`apply plugin: 'com.huawei.agconnect'`);
   }
 
-  return plugins.length > 0 ? plugins.join('\n') : '';
-};
-
-function removeLegacyGeneratedSections(contents: string, tags: string[]): string {
-  return tags.reduce((currentContents, tag) => {
-    return removeGeneratedContents(currentContents, tag) ?? currentContents;
-  }, contents);
+  return plugins.join('\n');
 }
-
-/**
- * 生成 defaultConfig 代码片段
- */
-
 
 export function applyAndroidAppBuildGradle(
   contents: string,
@@ -211,42 +279,63 @@ export function applyAndroidAppBuildGradle(
   appKey?: string,
   channel?: string
 ): string {
+  const resolvedConfig = getResolvedConfig(appKey, channel, packageName, vendorChannels);
+
   let nextContents = removeLegacyGeneratedSections(contents, LEGACY_DEFAULT_CONFIG_TAGS);
   nextContents = ensureNestedBlock(nextContents, /^\s*android\s*\{/, 'defaultConfig');
+  nextContents = ensureNestedBlock(nextContents, /^\s*defaultConfig\s*\{/, 'ndk');
   nextContents = ensureTopLevelBlock(nextContents, 'dependencies');
+  nextContents = removeLegacyGeneratedSections(nextContents, LEGACY_DEPENDENCY_TAGS);
 
-  const defaultConfigLine = findLineIndex(nextContents, /^\s*defaultConfig\s*\{/);
-  if (defaultConfigLine < 0) {
-    throw new Error('[MX_JPush_Expo] 未找到 defaultConfig 配置块');
-  }
-
-  nextContents = syncGeneratedContentsAtLine({
+  const ndkIndent = getChildIndent(
+    nextContents,
+    /^\s*ndk\s*\{/,
+    '[MX_JPush_Expo] 未找到 defaultConfig.ndk 配置块'
+  );
+  nextContents = replaceGeneratedContentsAtLine({
     src: nextContents,
-    newSrc: `${getNdkConfig()}\n${getManifestPlaceholders(packageName || '', appKey || '', channel || '', vendorChannels)}`,
-    tag: 'jpush-default-config',
-    lineIndex: defaultConfigLine,
-    offset: 1,
+    newSrc: getNdkAbiFilters(ndkIndent),
+    tag: 'jpush-ndk-abi-filters',
+    getLineIndex: (src) => getNdkRange(src).endLine,
+    offset: 0,
     comment: '//',
   }).contents;
 
-  const dependenciesLine = findLineIndex(nextContents, /^\s*dependencies\s*\{/);
-  if (dependenciesLine < 0) {
-    throw new Error('[MX_JPush_Expo] 未找到 dependencies 配置块');
-  }
-
-  nextContents = removeLegacyGeneratedSections(nextContents, LEGACY_DEPENDENCY_TAGS);
-  nextContents = syncGeneratedContentsAtLine({
+  const defaultConfigIndent = getChildIndent(
+    nextContents,
+    /^\s*defaultConfig\s*\{/,
+    '[MX_JPush_Expo] 未找到 defaultConfig 配置块'
+  );
+  nextContents = replaceGeneratedContentsAtLine({
     src: nextContents,
-    newSrc: getJPushDependencies(vendorChannels),
+    newSrc: getManifestPlaceholders(
+      resolvedConfig.packageName,
+      resolvedConfig.appKey,
+      resolvedConfig.channel,
+      resolvedConfig.vendorChannels,
+      defaultConfigIndent
+    ),
+    tag: 'jpush-manifest-placeholders',
+    getLineIndex: (src) => getDefaultConfigRange(src).endLine,
+    offset: 0,
+    comment: '//',
+  }).contents;
+
+  const dependenciesIndent = `${getLineIndent(
+    nextContents.split('\n')[getDependenciesLine(nextContents)]
+  )}    `;
+  nextContents = replaceGeneratedContentsAtLine({
+    src: nextContents,
+    newSrc: getJPushDependencies(resolvedConfig.vendorChannels, dependenciesIndent),
     tag: 'jpush-dependencies',
-    lineIndex: dependenciesLine,
+    getLineIndex: getDependenciesLine,
     offset: 1,
     comment: '//',
   }).contents;
 
   nextContents = syncGeneratedContentsAtEnd({
     src: nextContents,
-    newSrc: getApplyPlugins(vendorChannels),
+    newSrc: getApplyPlugins(resolvedConfig.vendorChannels),
     tag: 'jpush-apply-plugins',
     comment: '//',
   }).contents;
@@ -259,76 +348,20 @@ export function applyAndroidAppBuildGradle(
  */
 export function withAndroidAppBuildGradle(
   config: ExpoConfig,
-  props: Pick<ResolvedJPushPluginProps, 'packageName' | 'appKey' | 'channel' | 'vendorChannels'>
+  props: Pick<
+    ResolvedJPushPluginProps,
+    'packageName' | 'appKey' | 'channel' | 'vendorChannels'
+  >
 ): ExpoConfig {
   return withAppBuildGradle(config, (nextConfig) => {
-    const validator = new Validator(nextConfig.modResults.contents);
-
-    validator.register('abiFilters', (src) => {
-      console.log('\n[MX_JPush_Expo] 配置 build.gradle NDK abiFilters ...');
-
-      return mergeContents({
-        src,
-        newSrc: getNdkConfig(),
-        tag: 'jpush-ndk-config',
-        anchor: /versionName\s+["'][\d.]+["']/,
-        offset: 1,
-        comment: '//',
-      });
-    });
-
-    validator.register('JPUSH_APPKEY', (src) => {
-      console.log(
-        '\n[MX_JPush_Expo] 配置 build.gradle manifestPlaceholders ...'
-      );
-
-      return mergeContents({
-        src,
-        newSrc: getManifestPlaceholders(
-          props.packageName,
-          props.appKey,
-          props.channel,
-          props.vendorChannels
-        ),
-        tag: 'jpush-manifest-placeholders',
-        anchor: /versionName\s+["'][\d.]+["']/,
-        offset: 1,
-        comment: '//',
-      });
-    });
-
-    validator.register('jpush-dependencies', (src) => {
-      console.log('\n[MX_JPush_Expo] 配置 build.gradle JPush 依赖 ...');
-
-      return mergeContents({
-        src,
-        newSrc: getJPushDependencies(props.vendorChannels),
-        tag: 'jpush-dependencies',
-        anchor: /dependencies\s*\{/,
-        offset: 1,
-        comment: '//',
-      });
-    });
-
-    if (props.vendorChannels) {
-      const applyPlugins = getApplyPlugins(props.vendorChannels);
-      if (applyPlugins) {
-        validator.register('jpush-apply-plugins', (src) => {
-          console.log('\n[MX_JPush_Expo] 配置 build.gradle apply plugins ...');
-
-          return mergeContents({
-            src,
-            newSrc: applyPlugins,
-            tag: 'jpush-apply-plugins',
-            anchor: /^$/,
-            offset: 0,
-            comment: '//',
-          });
-        });
-      }
-    }
-
-    nextConfig.modResults.contents = validator.invoke();
+    console.log('\n[MX_JPush_Expo] 配置 Android app/build.gradle ...');
+    nextConfig.modResults.contents = applyAndroidAppBuildGradle(
+      nextConfig.modResults.contents,
+      props.vendorChannels,
+      props.packageName,
+      props.appKey,
+      props.channel
+    );
 
     return nextConfig;
   });


### PR DESCRIPTION
## Summary
- cover host `manifestPlaceholders` and missing/non-literal `versionName` with compileMods regression tests
- switch Android app/build.gradle injection to append JPush placeholders without relying on a `versionName` anchor

## Testing
- npm run build
- npm test -- --runInBand
- npm run lint