### PR TITLE
Sync 1.2.7 source metadata and entitlements regression tests

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -5,8 +5,6 @@
  * 支持 Expo SDK 55+ 和 React Native 0.83.6+
  * 
  * @author MuxiStudio
- * @version 1.2.5
- * 
  * 参考文档：
  * - JPush 集成 Expo: https://juejin.cn/post/7423235127716659239
  * - Expo SDK 53+ 集成极光推送 iOS Swift: https://juejin.cn/post/7554288083597885467

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mx-jpush-expo",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Expo 集成极光推送（JPush）一体化解决方案，支持 iOS/Android 厂商通道",
   "main": "app.plugin.js",
   "types": "plugin/build/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/konodioda727/JPush-Expo"
+    "url": "git+https://github.com/konodioda727/JPush-Expo.git"
   },
   "keywords": [
     "jpush",

--- a/plugin/__tests__/iosFixture.ts
+++ b/plugin/__tests__/iosFixture.ts
@@ -57,6 +57,7 @@ const xcode = requireFromTests(
 export const FIXTURE_ROOT = path.join(__dirname, 'fixtures', 'ios-project');
 export const APP_DELEGATE_PATH = ['ios', 'app', 'AppDelegate.swift'];
 export const APP_INFO_PLIST_PATH = ['ios', 'app', 'Info.plist'];
+export const APP_ENTITLEMENTS_PATH = ['ios', 'app', 'app.entitlements'];
 export const APP_BRIDGING_HEADER_PATH = ['ios', 'app', 'app-Bridging-Header.h'];
 export const PBXPROJ_PATH = ['ios', 'app.xcodeproj', 'project.pbxproj'];
 export const J_PUSH_IMPORTS = [
@@ -109,6 +110,22 @@ export function writeInfoPlist(
 ): void {
   fs.writeFileSync(
     getFixturePath(projectRoot, APP_INFO_PLIST_PATH),
+    plist.build(value)
+  );
+}
+
+export function readEntitlementsPlist(projectRoot: string): Record<string, unknown> {
+  return plist.parse(
+    fs.readFileSync(getFixturePath(projectRoot, APP_ENTITLEMENTS_PATH), 'utf8')
+  );
+}
+
+export function writeEntitlementsPlist(
+  projectRoot: string,
+  value: Record<string, unknown>
+): void {
+  fs.writeFileSync(
+    getFixturePath(projectRoot, APP_ENTITLEMENTS_PATH),
     plist.build(value)
   );
 }

--- a/plugin/__tests__/nativeIosMods.test.ts
+++ b/plugin/__tests__/nativeIosMods.test.ts
@@ -72,15 +72,15 @@ describe('native iOS config mods', () => {
 
   it('keeps app entitlements idempotent across repeated compiles', async () => {
     const projectRoot = createProjectRoot();
-    const entitlementsPath = getFixturePath(projectRoot, APP_ENTITLEMENTS_PATH);
 
     await compileIosMods(projectRoot);
-    const onceCompiled = fs.readFileSync(entitlementsPath, 'utf8');
+    const onceCompiled = readEntitlementsPlist(projectRoot);
 
     await compileIosMods(projectRoot);
-    const twiceCompiled = fs.readFileSync(entitlementsPath, 'utf8');
+    const twiceCompiled = readEntitlementsPlist(projectRoot);
 
-    expect(twiceCompiled).toBe(onceCompiled);
+    expect(twiceCompiled).toEqual(onceCompiled);
+    expect(twiceCompiled['aps-environment']).toBe('development');
   });
 
   it('merges host background modes instead of overwriting them', async () => {

--- a/plugin/__tests__/nativeIosMods.test.ts
+++ b/plugin/__tests__/nativeIosMods.test.ts
@@ -4,6 +4,7 @@ import { compileModsAsync } from 'expo/config-plugins';
 import withJPush from '../src';
 import {
   APP_BRIDGING_HEADER_PATH,
+  APP_ENTITLEMENTS_PATH,
   J_PUSH_IMPORTS,
   PBXPROJ_PATH,
   compileIosMods,
@@ -11,15 +12,77 @@ import {
   getFixturePath,
   getTargetBuildSettings,
   loadXcodeProject,
+  readEntitlementsPlist,
   readInfoPlist,
   registerIosFixtureLifecycleHooks,
   removeBridgingHeaderBuildSetting,
+  writeEntitlementsPlist,
   writeInfoPlist,
 } from './iosFixture';
 import { createExpoConfig, createPluginProps } from './testProps';
 registerIosFixtureLifecycleHooks();
 
 describe('native iOS config mods', () => {
+  it('creates app entitlements with development APNs by default', async () => {
+    const projectRoot = createProjectRoot();
+    const entitlementsPath = getFixturePath(projectRoot, APP_ENTITLEMENTS_PATH);
+
+    expect(fs.existsSync(entitlementsPath)).toBe(false);
+
+    await compileIosMods(projectRoot);
+
+    const entitlements = readEntitlementsPlist(projectRoot);
+    const appBuildSettings = getTargetBuildSettings(
+      loadXcodeProject(projectRoot),
+      'app'
+    );
+
+    expect(entitlements['aps-environment']).toBe('development');
+    expect(
+      appBuildSettings.every(
+        (buildSettings) =>
+          buildSettings.CODE_SIGN_ENTITLEMENTS === 'app/app.entitlements'
+      )
+    ).toBe(true);
+  });
+
+  it('creates app entitlements with production APNs when apsForProduction is true', async () => {
+    const projectRoot = createProjectRoot();
+
+    await compileIosMods(projectRoot, { apsForProduction: true });
+
+    const entitlements = readEntitlementsPlist(projectRoot);
+
+    expect(entitlements['aps-environment']).toBe('production');
+  });
+
+  it('does not overwrite an existing aps-environment entitlement', async () => {
+    const projectRoot = createProjectRoot();
+
+    writeEntitlementsPlist(projectRoot, {
+      'aps-environment': 'development',
+    });
+
+    await compileIosMods(projectRoot, { apsForProduction: true });
+
+    const entitlements = readEntitlementsPlist(projectRoot);
+
+    expect(entitlements['aps-environment']).toBe('development');
+  });
+
+  it('keeps app entitlements idempotent across repeated compiles', async () => {
+    const projectRoot = createProjectRoot();
+    const entitlementsPath = getFixturePath(projectRoot, APP_ENTITLEMENTS_PATH);
+
+    await compileIosMods(projectRoot);
+    const onceCompiled = fs.readFileSync(entitlementsPath, 'utf8');
+
+    await compileIosMods(projectRoot);
+    const twiceCompiled = fs.readFileSync(entitlementsPath, 'utf8');
+
+    expect(twiceCompiled).toBe(onceCompiled);
+  });
+
   it('merges host background modes instead of overwriting them', async () => {
     const projectRoot = createProjectRoot();
     const infoPlist = readInfoPlist(projectRoot);

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -5,8 +5,6 @@
  * 支持 Expo SDK 55+ 和 React Native 0.83.6+
  * 
  * @author MuxiStudio
- * @version 1.2.7
- * 
  * 参考文档：
  * - JPush 集成 Expo: https://juejin.cn/post/7423235127716659239
  * - Expo SDK 53+ 集成极光推送 iOS Swift: https://juejin.cn/post/7554288083597885467

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -5,7 +5,7 @@
  * 支持 Expo SDK 55+ 和 React Native 0.83.6+
  * 
  * @author MuxiStudio
- * @version 1.2.5
+ * @version 1.2.7
  * 
  * 参考文档：
  * - JPush 集成 Expo: https://juejin.cn/post/7423235127716659239
@@ -80,4 +80,4 @@ const withJPush: ConfigPlugin<JPushPluginProps> = (config, props) => {
 /**
  * 导出插件（使用 createRunOncePlugin 确保插件只运行一次）
  */
-export default createRunOncePlugin(withJPush, 'mx-jpush-expo', '1.2.5');
+export default createRunOncePlugin(withJPush, 'mx-jpush-expo', '1.2.7');

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -16,9 +16,12 @@
  */
 
 import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
+import packageJson from '../../package.json';
 import { JPushPluginProps, resolveProps, validateProps } from './types';
 import { withIOSConfig } from './ios';
 import { withAndroidConfig } from './android';
+
+const pluginVersion = packageJson.version;
 
 /**
  * JPush Expo Config Plugin 主入口
@@ -78,4 +81,4 @@ const withJPush: ConfigPlugin<JPushPluginProps> = (config, props) => {
 /**
  * 导出插件（使用 createRunOncePlugin 确保插件只运行一次）
  */
-export default createRunOncePlugin(withJPush, 'mx-jpush-expo', '1.2.7');
+export default createRunOncePlugin(withJPush, 'mx-jpush-expo', pluginVersion);


### PR DESCRIPTION
## Summary
- sync package/source metadata with the already-published npm 1.2.7 version
- normalize repository.url so npm publish dry-run no longer auto-corrects package metadata
- add native iOS fixture coverage for generated app entitlements and aps-environment behavior

## Notes
- This does not republish 1.2.7 and does not create a GitHub release.
- npm already reports latest as 1.2.7; this PR aligns the repository source of truth.

## Validation
- pnpm install --frozen-lockfile
- npm test -- --runInBand
- pnpm run lint
- npm publish --dry-run --access public