### PR TITLE
Verify npm package dry-run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Run lint
         run: npm run lint
+
+      - name: Check npm package contents
+        run: npm publish --dry-run --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         run: npm run lint
 
       - name: Check npm package contents
-        run: npm publish --dry-run --access public
+        run: npm pack --dry-run


### PR DESCRIPTION
## Summary
- add npm pack --dry-run to the quality workflow after lint
- keep the release-triggered Trusted Publishing workflow unchanged

## Notes
- npm publish --dry-run is not reliable in PR CI for this package because npm checks the registry and fails when the current package version is already published.
- npm pack --dry-run still validates the generated package contents without depending on registry publishability.

## Validation
- pnpm install --frozen-lockfile
- npm test -- --runInBand
- pnpm run lint
- npm pack --dry-run
- npx --yes github-actionlint@1.7.12 .github/workflows/ci.yml .github/workflows/publish.yml