### PR TITLE
Harden Expo 56 compatibility validation

### DIFF
--- a/.github/workflows/expo-56-smoke.yml
+++ b/.github/workflows/expo-56-smoke.yml
@@ -29,4 +29,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Expo 56 prebuild smoke
-        run: npm run test:prebuild:expo56
+        run: pnpm run test:prebuild:expo56

--- a/.github/workflows/expo-56-smoke.yml
+++ b/.github/workflows/expo-56-smoke.yml
@@ -1,0 +1,32 @@
+name: Expo 56 Prebuild Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prebuild-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Expo 56 prebuild smoke
+        run: npm run test:prebuild:expo56

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - iOS `AppDelegate.swift` 注入兼容 Swift 访问级别导入（SDK 56 默认 `internal import Expo`），import 锚点不再失配
 - `engines.node` 提升到 `>= 20.19.4`（Expo SDK 56 要求）
 - 更新 iOS fixture 至 SDK 56 模板，回归测试覆盖 `internal import` 场景
+- `channel` 默认使用 `developer-default`，`packageName` 默认读取 `expo.android.package`，减少基础接入配置
+- 新增 Expo 56 真实 `prebuild` smoke 脚本和手动 GitHub Actions workflow，覆盖发布包入口与 iOS / Android 生成结果
+- 补齐 `shell-quote` 传递依赖安全 override，并对齐 `@expo/dom-webview@56.0.5` 以消除 Expo 56 peer warning
+- 更新维护文档，明确发布前需要核对 npm 版本、GitHub tag 和 GitHub Release 页面
 
 ## v1.2.7 (2026-06-03)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,6 +80,12 @@ npm test -- --coverage
 
 # 运行 lint
 npm run lint
+
+# 检查传递依赖安全基线
+pnpm audit --audit-level moderate
+
+# 验证 Expo 56 真实 prebuild 输出
+npm run test:prebuild:expo56
 ```
 
 当前主线的测试重点：
@@ -207,6 +213,22 @@ describe('withMyPlugin', () => {
 });
 ```
 
+### Expo 56 prebuild smoke
+
+仓库提供 `npm run test:prebuild:expo56`，用于验证发布包入口和真实 Expo 56 模板：
+
+- 先构建插件并用 `npm pack` 生成本地 tarball
+- 在临时目录创建最小 Expo 56 应用
+- 安装 `mx-jpush-expo` tarball、`jpush-react-native@3.1.9` 和 `jcore-react-native@2.3.0`
+- 执行 `expo prebuild --clean --no-install`
+- 断言 iOS / Android 关键原生文件包含 JPush 注入结果
+
+本地调试时可保留临时目录：
+
+```bash
+MX_JPUSH_KEEP_SMOKE_DIR=1 npm run test:prebuild:expo56
+```
+
 ### 集成测试
 
 在实际项目中测试：
@@ -230,8 +252,7 @@ describe('withMyPlugin', () => {
          [
            "mx-jpush-expo",
            {
-             "appKey": "test-key",
-             "channel": "test-channel"
+             "appKey": "test-key"
            }
          ]
        ]
@@ -286,27 +307,33 @@ npm run build
 ```bash
 npm test -- --runInBand
 npm run lint
+pnpm audit --audit-level moderate
+npm run test:prebuild:expo56
 ```
 
 ### 4. 检查发布包
 
 ```bash
-npm pack
+npm pack --dry-run
 ```
 
-### 5. 发布
+### 5. 发布前核对
 
 ```bash
-npm publish
+npm view mx-jpush-expo version dist-tags --json
+gh release list --limit 10
+git tag --list 'v*' --sort=-v:refname | head
 ```
 
-### 6. 打 tag
+确认 `package.json`、npm 版本、GitHub tag 和 GitHub Release 页面使用同一个版本号。npm 发布成功但 GitHub Release 缺失时，不要把仓库状态视为发布完成。
 
-只有 `npm publish` 成功后，才在同一提交上补 tag：
+### 6. 发布
+
+通过 GitHub Release published 事件触发 `.github/workflows/publish.yml` 发布 npm 包。只有 npm 发布成功后，才在同一提交上确认 tag 和 release 页面：
 
 ```bash
-git tag v1.2.5
-git push origin v1.2.5
+npm view mx-jpush-expo version dist-tags --json
+gh release view v1.3.0
 ```
 
 ## 常见问题

--- a/README.md
+++ b/README.md
@@ -128,9 +128,8 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         'mx-jpush-expo',
         {
           appKey: process.env.JPUSH_APP_KEY ?? '',
-          channel: process.env.JPUSH_CHANNEL ?? 'developer-default',
-          packageName:
-            process.env.JPUSH_PKGNAME ?? config.android?.package ?? '',
+          channel: process.env.JPUSH_CHANNEL,
+          packageName: process.env.JPUSH_PKGNAME,
           apsForProduction: isProduction,
           vendorChannels: {
             huawei: { enabled: true },
@@ -168,7 +167,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
 ### 配置要点
 
-- `appKey`、`channel`、`packageName` 仍然是插件必填项
+- `appKey` 仍然是插件必填项
+- `channel` 默认使用 `developer-default`；只有需要区分渠道时才需要显式传入
+- `packageName` 默认读取 `expo.android.package`；如果项目未配置 Android 包名，则需要显式传入
 - iOS 初始化参数会写入 `Info.plist`，不再直接拼进 `AppDelegate.swift`
 - Android `manifestPlaceholders` 优先读取环境变量或 `gradle.properties`，缺失时会回退到插件配置里的 `appKey` / `channel` / `packageName`
 - 如果宿主已经定义了 `manifestPlaceholders`，插件会通过 `manifestPlaceholders += [...]` 追加 JPush 字段
@@ -235,7 +236,7 @@ JPUSH_XIAOMI_APP_KEY=your-xiaomi-app-key
 
 ### Android 配置
 
-- `packageName`：Android 应用包名，用于 `manifestPlaceholders`
+- `packageName`：Android 应用包名，用于 `manifestPlaceholders`，默认读取 `expo.android.package`
 - 厂商通道通过 `vendorChannels` 对象配置，每个厂商独立开关
 
 ## 插件会修改哪些原生文件
@@ -297,9 +298,9 @@ manifestPlaceholders += [
 
 不支持。JPush 需要原生工程和原生依赖，必须通过 `expo prebuild` 进入 Dev Client 或原生构建流程。
 
-### 为什么 iOS 仍然要求在插件配置里填写 `appKey` / `channel`？
+### 为什么 iOS 仍然要求在插件配置里填写 `appKey`？
 
-因为参数校验和 `Info.plist` 注入都发生在 Expo 配置阶段。它们不会再被直接拼进 `AppDelegate.swift`，但仍然需要在配置阶段提供。
+因为参数校验和 `Info.plist` 注入都发生在 Expo 配置阶段。它不会再被直接拼进 `AppDelegate.swift`，但仍然需要在配置阶段提供。`channel` 未传时会写入默认值 `developer-default`。
 
 ### Android 遇到 Gradle 插件版本错误怎么办？
 
@@ -323,6 +324,7 @@ npm 包入口是根目录的 `app.plugin.js`，它会加载发布产物 `plugin/
 npm run build
 npm run test -- --runInBand
 npm run lint
+npm run test:prebuild:expo56
 ```
 
 ### 测试覆盖重点
@@ -331,6 +333,7 @@ npm run lint
 - iOS `AppDelegate.swift` 注入与幂等
 - Android `Manifest`、Gradle、Settings 和 `gradle.properties` 原生输出
 - fixture-based 回归测试，确保 `compileModsAsync` 输出稳定
+- Expo 56 真实 `prebuild --clean --no-install` smoke，验证发布包入口和 iOS / Android 生成结果
 
 更多开发细节见 [DEVELOPMENT.md](./DEVELOPMENT.md)。
 
@@ -377,6 +380,8 @@ mx-jpush-expo/
 完整更新历史请查看 [CHANGELOG.md](./CHANGELOG.md)。
 
 - 支持 Expo 56（React Native 0.85.2 / React 19.2），仓库开发基线升级到 Expo SDK 56，Node.js 要求提升到 `>= 20.19.4`
+- `channel` 和 `packageName` 支持默认推断，基础接入只需要显式提供 `appKey`
+- 新增 Expo 56 真实 prebuild smoke，可验证发布包入口和 iOS / Android 生成结果
 - iOS `AppDelegate.swift` 注入兼容 Swift 访问级别导入（SDK 56 默认 `internal import Expo`）
 - iOS prebuild 现在自动写入 `.entitlements` 的 `aps-environment`，解决推送通知无法收到的问题；若已由 `app.json`、磁盘文件或其他插件配置，则保留已有值
 - iOS `UIBackgroundModes` 改为合并写入，不再覆盖宿主已有后台模式

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build": "tsc --project plugin/tsconfig.json",
     "clean": "rm -rf plugin/build",
     "test": "jest --config plugin/jest.config.js",
+    "test:prebuild:expo56": "node scripts/expo-56-prebuild-smoke.js",
     "prepare": "npm run build",
     "lint": "eslint plugin/src plugin/__tests__ --ext .ts"
   },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@expo/dom-webview": "^56.0.5",
     "@types/jest": "^29.5.14",
     "@types/node": "^18.19.130",
     "@typescript-eslint/eslint-plugin": "^8.59.3",
@@ -78,6 +79,7 @@
       "picomatch@^2": "2.3.2",
       "picomatch@^4": "4.0.4",
       "postcss": "8.5.14",
+      "shell-quote": "1.8.4",
       "ws@^8.18.3": "8.20.1",
       "xcode@3.0.1>uuid": "11.1.1"
     }

--- a/plugin/__tests__/withJPush.test.ts
+++ b/plugin/__tests__/withJPush.test.ts
@@ -53,7 +53,7 @@ describe('withJPush', () => {
 
   it('should throw error for invalid channel type', () => {
     expect(() => {
-      validateProps({
+      resolveProps({
         appKey: 'test-app-key',
         channel: 123 as any,
         packageName: 'com.example.test',
@@ -63,7 +63,7 @@ describe('withJPush', () => {
 
   it('should throw error for invalid packageName type', () => {
     expect(() => {
-      validateProps({
+      resolveProps({
         appKey: 'test-app-key',
         channel: 'test-channel',
         packageName: 123 as any,

--- a/plugin/__tests__/withJPush.test.ts
+++ b/plugin/__tests__/withJPush.test.ts
@@ -4,7 +4,7 @@
 
 import { ExpoConfig } from 'expo/config';
 import withJPush from '../src';
-import { validateProps } from '../src/types';
+import { resolveProps, validateProps } from '../src/types';
 
 describe('withJPush', () => {
   const mockConfig: ExpoConfig = {
@@ -22,13 +22,53 @@ describe('withJPush', () => {
     }).toThrow('[MX_JPush_Expo] appKey 是必填项');
   });
 
-  it('should throw error when channel is missing', () => {
+  it('should default channel when it is missing', () => {
+    const resolved = resolveProps({
+      appKey: 'test',
+      packageName: 'com.example.test',
+    });
+
+    expect(resolved.channel).toBe('developer-default');
+  });
+
+  it('should infer packageName from expo android package', () => {
+    const resolved = resolveProps(
+      {
+        appKey: 'test',
+        channel: 'test-channel',
+      },
+      'com.example.fromexpo'
+    );
+
+    expect(resolved.packageName).toBe('com.example.fromexpo');
+  });
+
+  it('should throw error when packageName cannot be resolved', () => {
+    expect(() => {
+      resolveProps({
+        appKey: 'test',
+      });
+    }).toThrow('[MX_JPush_Expo] packageName 是必填项');
+  });
+
+  it('should throw error for invalid channel type', () => {
     expect(() => {
       validateProps({
-        appKey: 'test',
+        appKey: 'test-app-key',
+        channel: 123 as any,
         packageName: 'com.example.test',
-      } as any);
-    }).toThrow('[MX_JPush_Expo] channel 是必填项');
+      });
+    }).toThrow('[MX_JPush_Expo] channel 必须是字符串');
+  });
+
+  it('should throw error for invalid packageName type', () => {
+    expect(() => {
+      validateProps({
+        appKey: 'test-app-key',
+        channel: 'test-channel',
+        packageName: 123 as any,
+      });
+    }).toThrow('[MX_JPush_Expo] packageName 必须是字符串');
   });
 
   it('should accept valid configuration', () => {
@@ -49,6 +89,22 @@ describe('withJPush', () => {
       packageName: 'com.example.test',
       apsForProduction: false,
     });
+
+    expect(result).toBeDefined();
+  });
+
+  it('should accept config with only appKey when android.package exists', () => {
+    const result = withJPush(
+      {
+        ...mockConfig,
+        android: {
+          package: 'com.example.fromconfig',
+        },
+      },
+      {
+        appKey: 'test-app-key',
+      }
+    );
 
     expect(result).toBeDefined();
   });

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -64,7 +64,7 @@ const withJPush: ConfigPlugin<JPushPluginProps> = (config, props) => {
   try {
     // 验证配置参数
     validateProps(props);
-    const resolvedProps = resolveProps(props);
+    const resolvedProps = resolveProps(props, config.android?.package);
 
     // 应用 iOS 配置
     config = withIOSConfig(config, resolvedProps);

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -78,15 +78,17 @@ export interface JPushPluginProps {
   appKey: string;
 
   /**
-   * 极光推送 Channel（必填）
+   * 极光推送 Channel（可选）
+   * @default "developer-default"
    */
-  channel: string;
+  channel?: string;
 
   /**
-   * Android 包名（必填）
+   * Android 包名（可选）
    * 需要与极光推送控制台注册的包名一致
+   * @default config.android.package
    */
-  packageName: string;
+  packageName?: string;
 
   /**
    * iOS 推送环境（可选）
@@ -104,6 +106,8 @@ export interface JPushPluginProps {
  * 插件内部使用的已归一化配置
  */
 export interface ResolvedJPushPluginProps extends JPushPluginProps {
+  channel: string;
+  packageName: string;
   apsForProduction: boolean;
 }
 
@@ -177,12 +181,12 @@ export function validateProps(props: JPushPluginProps | undefined): asserts prop
     throw new Error('[MX_JPush_Expo] appKey 是必填项，且必须是字符串');
   }
 
-  if (!props.channel || typeof props.channel !== 'string') {
-    throw new Error('[MX_JPush_Expo] channel 是必填项，且必须是字符串');
+  if (props.channel !== undefined && typeof props.channel !== 'string') {
+    throw new Error('[MX_JPush_Expo] channel 必须是字符串');
   }
 
-  if (!props.packageName || typeof props.packageName !== 'string') {
-    throw new Error('[MX_JPush_Expo] packageName 是必填项，且必须是字符串');
+  if (props.packageName !== undefined && typeof props.packageName !== 'string') {
+    throw new Error('[MX_JPush_Expo] packageName 必须是字符串');
   }
 
   if (props.apsForProduction !== undefined && typeof props.apsForProduction !== 'boolean') {
@@ -196,10 +200,22 @@ export function validateProps(props: JPushPluginProps | undefined): asserts prop
  * 归一化插件参数，补齐内部默认值
  */
 export function resolveProps(
-  props: JPushPluginProps
+  props: JPushPluginProps,
+  androidPackageName?: string
 ): ResolvedJPushPluginProps {
+  const channel = props.channel?.trim() || 'developer-default';
+  const packageName = props.packageName?.trim() || androidPackageName?.trim();
+
+  if (!packageName) {
+    throw new Error(
+      '[MX_JPush_Expo] packageName 是必填项，且必须是非空字符串；也可以通过 expo.android.package 自动推断'
+    );
+  }
+
   return {
     ...props,
+    channel,
+    packageName,
     apsForProduction: props.apsForProduction ?? false,
   };
 }

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -203,6 +203,8 @@ export function resolveProps(
   props: JPushPluginProps,
   androidPackageName?: string
 ): ResolvedJPushPluginProps {
+  validateProps(props);
+
   const channel = props.channel?.trim() || 'developer-default';
   const packageName = props.packageName?.trim() || androidPackageName?.trim();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   picomatch@^2: 2.3.2
   picomatch@^4: 4.0.4
   postcss: 8.5.14
+  shell-quote: 1.8.4
   ws@^8.18.3: 8.20.1
   xcode@3.0.1>uuid: 11.1.1
 
@@ -23,6 +24,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.0)
+      '@expo/dom-webview':
+        specifier: ^56.0.5
+        version: 56.0.5(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -40,7 +44,7 @@ importers:
         version: 10.4.0
       expo:
         specifier: ^56.0.0
-        version: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -939,8 +943,8 @@ packages:
       react-native:
         optional: true
 
-  '@expo/dom-webview@55.0.6':
-    resolution: {integrity: sha512-ZNm8tiNEZysxrr36J0x4mOCGyJDcaIvL/3tMxBz0VJIJDcV19xjuJAhJQxHovu+jKx6s9tRyEAINa1mdrzV39g==}
+  '@expo/dom-webview@56.0.5':
+    resolution: {integrity: sha512-UIEJxkLg6cHqofKrpWpkn9E6ApxVRtCgZhZkARPr9VV7rBVloJgeroTHs31YgU/JpbI5lLQOnfOlGo54W6C2Ew==}
     peerDependencies:
       expo: '*'
       react: '*'
@@ -2553,24 +2557,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3234,8 +3242,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
@@ -4682,7 +4690,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@expo/cli@56.1.15(@expo/dom-webview@55.0.6)(expo-constants@56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)))(expo-font@56.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1))(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@expo/cli@56.1.15(@expo/dom-webview@56.0.5)(expo-constants@56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)))(expo-font@56.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1))(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@5.9.3)
@@ -4692,7 +4700,7 @@ snapshots:
       '@expo/image-utils': 0.10.1(typescript@5.9.3)
       '@expo/inline-modules': 0.0.11(typescript@5.9.3)
       '@expo/json-file': 10.2.0
-      '@expo/log-box': 56.0.13(@expo/dom-webview@55.0.6)(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
       '@expo/metro': 56.0.0
       '@expo/metro-config': 56.0.14(expo@56.0.11)(typescript@5.9.3)
       '@expo/metro-file-map': 56.0.3
@@ -4717,7 +4725,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -4812,9 +4820,9 @@ snapshots:
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)
 
-  '@expo/dom-webview@55.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)':
+  '@expo/dom-webview@56.0.5(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)
 
@@ -4877,11 +4885,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/log-box@56.0.13(@expo/dom-webview@55.0.6)(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)':
+  '@expo/log-box@56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@expo/dom-webview': 55.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
       anser: 1.4.10
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)
       stacktrace-parser: 0.1.11
@@ -4912,7 +4920,7 @@ snapshots:
       postcss: 8.5.14
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4999,7 +5007,7 @@ snapshots:
   '@expo/router-server@56.0.14(expo-constants@56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)))(expo-font@56.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1))(expo-server@56.0.5)(expo@56.0.11)(react@18.3.1)':
     dependencies:
       debug: 4.4.3
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       expo-constants: 56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))
       expo-font: 56.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
       expo-server: 56.0.5
@@ -5813,7 +5821,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -6206,7 +6214,7 @@ snapshots:
   expo-asset@56.0.17(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.10.1(typescript@5.9.3)
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       expo-constants: 56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)
@@ -6217,26 +6225,26 @@ snapshots:
   expo-constants@56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)):
     dependencies:
       '@expo/env': 2.3.0
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react-native: 0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
 
   expo-file-system@56.0.8(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)):
     dependencies:
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react-native: 0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)
 
   expo-font@56.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1):
     dependencies:
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)
 
   expo-keep-awake@56.0.3(expo@56.0.11)(react@18.3.1):
     dependencies:
-      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      expo: 56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react: 18.3.1
 
   expo-modules-autolinking@56.0.15(typescript@5.9.3):
@@ -6263,16 +6271,16 @@ snapshots:
 
   expo-server@56.0.5: {}
 
-  expo@56.0.11(@babel/core@7.28.5)(@expo/dom-webview@55.0.6)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  expo@56.0.11(@babel/core@7.28.5)(@expo/dom-webview@56.0.5)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.28.4
-      '@expo/cli': 56.1.15(@expo/dom-webview@55.0.6)(expo-constants@56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)))(expo-font@56.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1))(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@expo/cli': 56.1.15(@expo/dom-webview@56.0.5)(expo-constants@56.0.18(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1)))(expo-font@56.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1))(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@expo/config': 56.0.9(typescript@5.9.3)
       '@expo/config-plugins': 56.0.8(typescript@5.9.3)
       '@expo/devtools': 56.0.2(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
       '@expo/fingerprint': 0.19.4
       '@expo/local-build-cache-provider': 56.0.8(typescript@5.9.3)
-      '@expo/log-box': 56.0.13(@expo/dom-webview@55.0.6)(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
       '@expo/metro': 56.0.0
       '@expo/metro-config': 56.0.14(expo@56.0.11)(typescript@5.9.3)
       '@ungap/structured-clone': 1.3.1
@@ -6290,7 +6298,7 @@ snapshots:
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.2
     optionalDependencies:
-      '@expo/dom-webview': 55.0.6(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -7691,7 +7699,7 @@ snapshots:
 
   react-devtools-core@5.3.2:
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -7900,7 +7908,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   signal-exit@3.0.7: {}
 

--- a/scripts/expo-56-prebuild-smoke.js
+++ b/scripts/expo-56-prebuild-smoke.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { pathToFileURL } = require('url');
 
 const repoRoot = path.resolve(__dirname, '..');
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mx-jpush-expo56-'));
@@ -51,6 +52,7 @@ try {
   });
   const [{ filename }] = JSON.parse(packOutput);
   tarballPath = path.join(repoRoot, filename);
+  const tarballUrl = pathToFileURL(tarballPath).href;
 
   fs.mkdirSync(appRoot, { recursive: true });
   fs.writeFileSync(
@@ -70,7 +72,7 @@ try {
           'react-native': '0.85.2',
           'jpush-react-native': '3.1.9',
           'jcore-react-native': '2.3.0',
-          'mx-jpush-expo': `file:${tarballPath}`,
+          'mx-jpush-expo': tarballUrl,
         },
         devDependencies: {},
       },
@@ -132,7 +134,7 @@ try {
   );
 
   run('npm', ['install', '--no-audit', '--no-fund'], { cwd: appRoot });
-  run('npx', ['expo', 'prebuild', '--clean', '--no-install'], { cwd: appRoot });
+  run('npm', ['exec', '--', 'expo', 'prebuild', '--clean', '--no-install'], { cwd: appRoot });
 
   const appBuildGradle = read('android/app/build.gradle');
   assertContains(appBuildGradle, 'manifestPlaceholders += [', 'android/app/build.gradle');
@@ -142,9 +144,9 @@ try {
   assertContains(appBuildGradle, 'JPUSH_PKGNAME', 'android/app/build.gradle');
   assertContains(appBuildGradle, 'com.example.jpushexpo56', 'android/app/build.gradle');
   assertContains(appBuildGradle, "implementation project(':jpush-react-native')", 'android/app/build.gradle');
-  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:huawei:5.9.0'", 'android/app/build.gradle');
-  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:fcm:5.9.0'", 'android/app/build.gradle');
-  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:xiaomi:5.9.0'", 'android/app/build.gradle');
+  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:huawei:", 'android/app/build.gradle');
+  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:fcm:", 'android/app/build.gradle');
+  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:xiaomi:", 'android/app/build.gradle');
 
   const manifest = read('android/app/src/main/AndroidManifest.xml');
   assertContains(manifest, 'android:name="JPUSH_APPKEY"', 'AndroidManifest.xml');

--- a/scripts/expo-56-prebuild-smoke.js
+++ b/scripts/expo-56-prebuild-smoke.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mx-jpush-expo56-'));
+const appRoot = path.join(tmpRoot, 'app');
+let tarballPath;
+
+function run(command, args, options = {}) {
+  console.log(`\n$ ${command} ${args.join(' ')}`);
+  execFileSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      CI: process.env.CI ?? '1',
+      EXPO_NO_TELEMETRY: '1',
+      npm_config_yes: 'true',
+    },
+  });
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8');
+}
+
+function assertContains(haystack, needle, label) {
+  if (!haystack.includes(needle)) {
+    throw new Error(`${label} is missing expected content: ${needle}`);
+  }
+}
+
+function assertFile(relativePath) {
+  const filePath = path.join(appRoot, relativePath);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Expected file to exist: ${relativePath}`);
+  }
+  return filePath;
+}
+
+try {
+  run('npm', ['run', 'build']);
+
+  const packOutput = execFileSync('npm', ['pack', '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  const [{ filename }] = JSON.parse(packOutput);
+  tarballPath = path.join(repoRoot, filename);
+
+  fs.mkdirSync(appRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(appRoot, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'mx-jpush-expo56-smoke',
+        version: '1.0.0',
+        private: true,
+        scripts: {
+          prebuild: 'expo prebuild',
+        },
+        dependencies: {
+          '@expo/dom-webview': '56.0.5',
+          expo: '56.0.11',
+          react: '19.2.3',
+          'react-native': '0.85.2',
+          'jpush-react-native': '3.1.9',
+          'jcore-react-native': '2.3.0',
+          'mx-jpush-expo': `file:${tarballPath}`,
+        },
+        devDependencies: {},
+      },
+      null,
+      2
+    )}\n`
+  );
+  fs.writeFileSync(
+    path.join(appRoot, 'app.json'),
+    `${JSON.stringify(
+      {
+        expo: {
+          name: 'JPush Expo 56 Smoke',
+          slug: 'jpush-expo-56-smoke',
+          version: '1.0.0',
+          ios: {
+            bundleIdentifier: 'com.example.jpushexpo56',
+          },
+          android: {
+            package: 'com.example.jpushexpo56',
+          },
+          plugins: [
+            [
+              'mx-jpush-expo',
+              {
+                appKey: 'smoke-app-key',
+                apsForProduction: false,
+                vendorChannels: {
+                  huawei: {
+                    enabled: true,
+                  },
+                  fcm: {
+                    enabled: true,
+                  },
+                  xiaomi: {
+                    appId: 'smoke-xiaomi-id',
+                    appKey: 'smoke-xiaomi-key',
+                  },
+                },
+              },
+            ],
+          ],
+        },
+      },
+      null,
+      2
+    )}\n`
+  );
+  fs.writeFileSync(
+    path.join(appRoot, 'App.tsx'),
+    [
+      "import { Text, View } from 'react-native';",
+      '',
+      'export default function App() {',
+      "  return <View><Text>JPush Expo 56 Smoke</Text></View>;",
+      '}',
+      '',
+    ].join('\n')
+  );
+
+  run('npm', ['install', '--no-audit', '--no-fund'], { cwd: appRoot });
+  run('npx', ['expo', 'prebuild', '--clean', '--no-install'], { cwd: appRoot });
+
+  const appBuildGradle = read('android/app/build.gradle');
+  assertContains(appBuildGradle, 'manifestPlaceholders += [', 'android/app/build.gradle');
+  assertContains(appBuildGradle, 'JPUSH_APPKEY', 'android/app/build.gradle');
+  assertContains(appBuildGradle, 'JPUSH_CHANNEL', 'android/app/build.gradle');
+  assertContains(appBuildGradle, 'developer-default', 'android/app/build.gradle');
+  assertContains(appBuildGradle, 'JPUSH_PKGNAME', 'android/app/build.gradle');
+  assertContains(appBuildGradle, 'com.example.jpushexpo56', 'android/app/build.gradle');
+  assertContains(appBuildGradle, "implementation project(':jpush-react-native')", 'android/app/build.gradle');
+  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:huawei:5.9.0'", 'android/app/build.gradle');
+  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:fcm:5.9.0'", 'android/app/build.gradle');
+  assertContains(appBuildGradle, "implementation 'cn.jiguang.sdk.plugin:xiaomi:5.9.0'", 'android/app/build.gradle');
+
+  const manifest = read('android/app/src/main/AndroidManifest.xml');
+  assertContains(manifest, 'android:name="JPUSH_APPKEY"', 'AndroidManifest.xml');
+  assertContains(manifest, 'android:name="JPUSH_CHANNEL"', 'AndroidManifest.xml');
+
+  const settingsGradle = read('android/settings.gradle');
+  assertContains(settingsGradle, "include ':jpush-react-native'", 'android/settings.gradle');
+  assertContains(settingsGradle, "include ':jcore-react-native'", 'android/settings.gradle');
+
+  const projectBuildGradle = read('android/build.gradle');
+  assertContains(projectBuildGradle, "maven { url 'https://developer.huawei.com/repo/' }", 'android/build.gradle');
+  assertContains(projectBuildGradle, "classpath 'com.google.gms:google-services:4.4.0'", 'android/build.gradle');
+
+  const appDelegatePath = assertFile('ios/JPushExpo56Smoke/AppDelegate.swift');
+  const appDelegate = fs.readFileSync(appDelegatePath, 'utf8');
+  assertContains(appDelegate, 'import UserNotifications', 'AppDelegate.swift');
+  assertContains(appDelegate, 'JPUSHService.setup(withOption: launchOptions', 'AppDelegate.swift');
+  assertContains(appDelegate, 'extension AppDelegate: JPUSHRegisterDelegate', 'AppDelegate.swift');
+
+  const infoPlist = read('ios/JPushExpo56Smoke/Info.plist');
+  assertContains(infoPlist, 'JPUSH_APPKEY', 'Info.plist');
+  assertContains(infoPlist, 'JPUSH_CHANNEL', 'Info.plist');
+  assertContains(infoPlist, 'developer-default', 'Info.plist');
+
+  const entitlements = read('ios/JPushExpo56Smoke/JPushExpo56Smoke.entitlements');
+  assertContains(entitlements, 'aps-environment', 'JPushExpo56Smoke.entitlements');
+  assertContains(entitlements, 'development', 'JPushExpo56Smoke.entitlements');
+
+  const bridgingHeader = read('ios/JPushExpo56Smoke/JPushExpo56Smoke-Bridging-Header.h');
+  assertContains(bridgingHeader, '#import <JPUSHService.h>', 'Bridging Header');
+  assertContains(bridgingHeader, '#import <RCTJPushModule.h>', 'Bridging Header');
+
+  console.log(`\nExpo 56 prebuild smoke passed in ${appRoot}`);
+} finally {
+  if (tarballPath) {
+    fs.rmSync(tarballPath, { force: true });
+  }
+
+  if (process.env.MX_JPUSH_KEEP_SMOKE_DIR !== '1') {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } else {
+    console.log(`\nKept smoke directory: ${tmpRoot}`);
+  }
+}


### PR DESCRIPTION
Closes #30.

## Summary
- make `channel` optional with the existing `developer-default` fallback, and infer `packageName` from `expo.android.package` when it is not passed explicitly
- patch the Expo 56 dependency/audit surface by updating `@expo/dom-webview` and pinning `shell-quote`
- add a repeatable Expo 56 prebuild smoke script plus a manual GitHub Actions workflow
- document the new defaults, smoke command, and release preflight checks

## Validation
- `pnpm install --frozen-lockfile`
- `npm run build`
- `npm test -- --runInBand`
- `npm run lint`
- `pnpm audit --audit-level moderate`
- `npm run test:prebuild:expo56`
- `npm pack --dry-run`
- `git diff --check`

## Notes
- The smoke test validates Expo 56 prebuild output for Android and iOS. It does not run a native device build or verify push delivery against JPush services.
