### PR TITLE
Prepare v1.3.1 npm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 历史版本更新从 README 中拆出，便于首页专注接入说明与使用导航。
+## v1.3.1 (2026-06-18)
+
+- 重新发布 v1.3.0 整合优化内容到新的 npm 版本，避免覆盖已存在的 `mx-jpush-expo@1.3.0`
+- 包含 Expo 56 smoke、`channel` / `packageName` 默认值、iOS entitlements、CI package guard 和 audit overrides
+
 ## v1.3.0 (2026-06-18)
 
 - 支持 Expo 56（React Native 0.85.2 / React 19.2 / Hermes v1）

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -333,7 +333,7 @@ git tag --list 'v*' --sort=-v:refname | head
 
 ```bash
 npm view mx-jpush-expo version dist-tags --json
-gh release view v1.3.0
+gh release view v1.3.1
 ```
 
 ## 常见问题

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mx-jpush-expo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Expo 集成极光推送（JPush）一体化解决方案，支持 iOS/Android 厂商通道",
   "main": "app.plugin.js",
   "types": "plugin/build/index.d.ts",


### PR DESCRIPTION
## Summary

Prepare `mx-jpush-expo` v1.3.1 as the publishable release for the merged #32 content.

`mx-jpush-expo@1.3.0` already exists on npm and points at the older `e0eb79c` package contents, so npm cannot publish the merged #32 contents under the same version. This PR only bumps metadata to `1.3.1` and documents that it republishes the v1.3.0 integrated hardening content under a new npm version.

## Validation

- `pnpm run build`
- `pnpm test --runInBand`
- `pnpm run lint`
- `npm pack --dry-run`
- `pnpm audit --audit-level moderate` (passes the moderate gate; one low remains)
- `git diff --check`

## Release

After merge, create GitHub Release `v1.3.1` on the merge commit. The publish workflow should publish `mx-jpush-expo@1.3.1` to npm.