### PR TITLE
fix(android): escape Gradle placeholder fallbacks

### DIFF
--- a/plugin/__tests__/androidTransforms.test.ts
+++ b/plugin/__tests__/androidTransforms.test.ts
@@ -13,6 +13,8 @@ const readFixture = (fixturePath: string): string =>
 const TEST_APP_KEY = 'demo-app-key';
 const TEST_CHANNEL = 'demo-channel';
 const TEST_PACKAGE_NAME = 'com.demo.app';
+const gradleStringLiteral = (value: string): string =>
+  (JSON.stringify(value) ?? '""').replace(/\$/g, '\\$');
 
 describe('Android transforms', () => {
   it('should inject app/build.gradle for enabled vendors and remain idempotent', () => {
@@ -63,15 +65,18 @@ describe('Android transforms', () => {
     );
 
     expect(transformed).toContain(
-      `JPUSH_PKGNAME: System.getenv("JPUSH_PKGNAME") ?: (project.findProperty("JPUSH_PKGNAME") ?: ${JSON.stringify(packageName)})`
+      `JPUSH_PKGNAME: System.getenv("JPUSH_PKGNAME") ?: (project.findProperty("JPUSH_PKGNAME") ?: ${gradleStringLiteral(packageName)})`
     );
     expect(transformed).toContain(
-      `JPUSH_APPKEY: System.getenv("JPUSH_APP_KEY") ?: (project.findProperty("JPUSH_APP_KEY") ?: ${JSON.stringify(appKey)})`
+      `JPUSH_APPKEY: System.getenv("JPUSH_APP_KEY") ?: (project.findProperty("JPUSH_APP_KEY") ?: ${gradleStringLiteral(appKey)})`
     );
     expect(transformed).toContain(
-      `JPUSH_CHANNEL: System.getenv("JPUSH_CHANNEL") ?: (project.findProperty("JPUSH_CHANNEL") ?: ${JSON.stringify(channel)})`
+      `JPUSH_CHANNEL: System.getenv("JPUSH_CHANNEL") ?: (project.findProperty("JPUSH_CHANNEL") ?: ${gradleStringLiteral(channel)})`
     );
     expect(transformed).not.toContain('\nprintln "PWNED"');
+    expect(transformed.replace(/\\\$\{project\.rootDir\}/g, '')).not.toContain(
+      '${project.rootDir}'
+    );
   });
 
   it('should remove vendor-only app/build.gradle sections when vendors are disabled', () => {

--- a/plugin/__tests__/androidTransforms.test.ts
+++ b/plugin/__tests__/androidTransforms.test.ts
@@ -47,6 +47,33 @@ describe('Android transforms', () => {
     expect(transformed).toContain(`apply plugin: 'com.huawei.agconnect'`);
     expect(repeated).toBe(transformed);
   });
+
+  it('should escape app/build.gradle JPush fallback string literals', () => {
+    const fixture = readFixture('android/app-build.gradle.fixture');
+    const packageName = 'com.demo."pkg\\${project.rootDir}';
+    const appKey = 'demo" )\nprintln "PWNED"\n// \\ ${project.rootDir}';
+    const channel = 'demo-channel"\\\n${project.rootDir}';
+
+    const transformed = applyAndroidAppBuildGradle(
+      fixture,
+      undefined,
+      packageName,
+      appKey,
+      channel
+    );
+
+    expect(transformed).toContain(
+      `JPUSH_PKGNAME: System.getenv("JPUSH_PKGNAME") ?: (project.findProperty("JPUSH_PKGNAME") ?: ${JSON.stringify(packageName)})`
+    );
+    expect(transformed).toContain(
+      `JPUSH_APPKEY: System.getenv("JPUSH_APP_KEY") ?: (project.findProperty("JPUSH_APP_KEY") ?: ${JSON.stringify(appKey)})`
+    );
+    expect(transformed).toContain(
+      `JPUSH_CHANNEL: System.getenv("JPUSH_CHANNEL") ?: (project.findProperty("JPUSH_CHANNEL") ?: ${JSON.stringify(channel)})`
+    );
+    expect(transformed).not.toContain('\nprintln "PWNED"');
+  });
+
   it('should remove vendor-only app/build.gradle sections when vendors are disabled', () => {
     const fixture = readFixture('android/app-build.gradle.fixture');
 

--- a/plugin/src/android/appBuildGradle.ts
+++ b/plugin/src/android/appBuildGradle.ts
@@ -44,7 +44,8 @@ type AndroidBuildGradleConfigInput = {
 const gradleEnv = (key: string, fallback = '""'): string =>
   `System.getenv("${key}") ?: (project.findProperty("${key}") ?: ${fallback})`;
 
-const gradleStringLiteral = (value: string): string => JSON.stringify(value) ?? '""';
+const gradleStringLiteral = (value: string): string =>
+  (JSON.stringify(value) ?? '""').replace(/\$/g, '\\$');
 
 function removeLegacyGeneratedSections(contents: string, tags: string[]): string {
   return tags.reduce((currentContents, tag) => {

--- a/plugin/src/android/appBuildGradle.ts
+++ b/plugin/src/android/appBuildGradle.ts
@@ -44,6 +44,8 @@ type AndroidBuildGradleConfigInput = {
 const gradleEnv = (key: string, fallback = '""'): string =>
   `System.getenv("${key}") ?: (project.findProperty("${key}") ?: ${fallback})`;
 
+const gradleStringLiteral = (value: string): string => JSON.stringify(value) ?? '""';
+
 function removeLegacyGeneratedSections(contents: string, tags: string[]): string {
   return tags.reduce((currentContents, tag) => {
     return removeGeneratedContents(currentContents, tag) ?? currentContents;
@@ -121,9 +123,9 @@ function getManifestPlaceholders(
   indent: string
 ): string {
   const placeholders: string[] = [
-    `JPUSH_PKGNAME: ${gradleEnv('JPUSH_PKGNAME', `"${packageName}"`)}`,
-    `JPUSH_APPKEY: ${gradleEnv('JPUSH_APP_KEY', `"${appKey}"`)}`,
-    `JPUSH_CHANNEL: ${gradleEnv('JPUSH_CHANNEL', `"${channel}"`)}`,
+    `JPUSH_PKGNAME: ${gradleEnv('JPUSH_PKGNAME', gradleStringLiteral(packageName))}`,
+    `JPUSH_APPKEY: ${gradleEnv('JPUSH_APP_KEY', gradleStringLiteral(appKey))}`,
+    `JPUSH_CHANNEL: ${gradleEnv('JPUSH_CHANNEL', gradleStringLiteral(channel))}`,
   ];
 
   if (vendorChannels?.meizu) {


### PR DESCRIPTION
## Summary
- Escape Android Gradle fallback literals for JPUSH_PKGNAME, JPUSH_APPKEY, and JPUSH_CHANNEL with JSON string literals.
- Preserve vendor channel secret fallbacks as env/property-only values.
- Add regression coverage for quote, newline, backslash, and ${...} payloads so injected data cannot become standalone Gradle statements.

## Validation
- pnpm test -- --runInBand nativeAndroidMods.test.ts androidTransforms.test.ts
- pnpm exec jest --config plugin/jest.config.js --runInBand plugin/__tests__/nativeAndroidMods.test.ts plugin/__tests__/androidTransforms.test.ts
- pnpm run build
- pnpm exec jest --config plugin/jest.config.js --runInBand

Note: pnpm test -- --runInBand exits with no tests found in this repository because the extra argv is treated as a Jest pattern by the package script; the direct pnpm exec jest commands above run Jest serially.